### PR TITLE
Fix updater public key configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Configure updater public key
+        env:
+          TAURI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+        run: node scripts/configure-updater-public-key.mjs
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/docs/desktop-updates.md
+++ b/docs/desktop-updates.md
@@ -33,7 +33,11 @@ Store these repository Actions secrets:
 
 - `TAURI_SIGNING_PRIVATE_KEY`: contents of the private key file;
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: password chosen during generation;
-- `TAURI_UPDATER_PUBLIC_KEY`: the printed public key.
+- `TAURI_UPDATER_PUBLIC_KEY`: the exact Base64 contents of the `.pub` file generated next to the private key.
+
+The release workflow validates this public key before installing dependencies and
+injects it into Tauri's updater configuration for both bundle signing and runtime
+verification. The key is never printed by the workflow.
 
 Never commit the private key or its password. The public key is embedded at compile time only in release builds. Local builds deliberately do not register the updater plugin.
 

--- a/scripts/configure-updater-public-key.mjs
+++ b/scripts/configure-updater-public-key.mjs
@@ -1,0 +1,65 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function validateUpdaterPublicKey(value) {
+  const publicKey = value?.trim();
+  if (!publicKey) {
+    throw new Error("TAURI_UPDATER_PUBLIC_KEY is required");
+  }
+
+  if (
+    publicKey.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(publicKey)
+  ) {
+    throw new Error(
+      "TAURI_UPDATER_PUBLIC_KEY must be the Base64 contents of the Tauri-generated .pub file",
+    );
+  }
+
+  const decoded = Buffer.from(publicKey, "base64").toString("utf8");
+  const lines = decoded.trimEnd().split(/\r?\n/);
+  if (
+    !lines[0]?.startsWith("untrusted comment:") ||
+    !lines[1]?.startsWith("RW")
+  ) {
+    throw new Error(
+      "TAURI_UPDATER_PUBLIC_KEY does not decode to a Minisign public key",
+    );
+  }
+
+  return publicKey;
+}
+
+export function injectUpdaterPublicKey(config, value) {
+  const publicKey = validateUpdaterPublicKey(value);
+  return {
+    ...config,
+    plugins: {
+      ...config.plugins,
+      updater: {
+        ...config.plugins?.updater,
+        pubkey: publicKey,
+      },
+    },
+  };
+}
+
+export async function configureUpdaterPublicKey({
+  publicKey,
+  configPath = "src-tauri/tauri.conf.json",
+}) {
+  const resolvedPath = resolve(configPath);
+  const config = JSON.parse(await readFile(resolvedPath, "utf8"));
+  const configured = injectUpdaterPublicKey(config, publicKey);
+  await writeFile(resolvedPath, `${JSON.stringify(configured, null, 2)}\n`);
+  return resolvedPath;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const configPath = await configureUpdaterPublicKey({
+    publicKey: process.env.TAURI_UPDATER_PUBLIC_KEY,
+    configPath: process.argv[2],
+  });
+  console.log(`Configured updater public key in ${configPath}`);
+}

--- a/scripts/configure-updater-public-key.test.mjs
+++ b/scripts/configure-updater-public-key.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  configureUpdaterPublicKey,
+  injectUpdaterPublicKey,
+  validateUpdaterPublicKey,
+} from "./configure-updater-public-key.mjs";
+
+const encodedPublicKey = Buffer.from(
+  [
+    "untrusted comment: minisign public key 0123456789ABCDEF",
+    "RWRERERERERERERERERERERERERERERERERERERERERERERERERERE",
+    "",
+  ].join("\n"),
+).toString("base64");
+
+test("validates a Tauri-generated updater public key", () => {
+  assert.equal(validateUpdaterPublicKey(encodedPublicKey), encodedPublicKey);
+});
+
+test("rejects an empty updater public key", () => {
+  assert.throws(
+    () => validateUpdaterPublicKey(""),
+    /TAURI_UPDATER_PUBLIC_KEY is required/,
+  );
+});
+
+test("rejects Base64 that is not a Minisign public key", () => {
+  const invalid = Buffer.from("RWRERERERERERERERERE\n").toString("base64");
+  assert.throws(
+    () => validateUpdaterPublicKey(invalid),
+    /does not decode to a Minisign public key/,
+  );
+});
+
+test("injects the updater key without losing existing configuration", () => {
+  const config = {
+    productName: "Pi Agent",
+    plugins: {
+      updater: {
+        endpoints: ["https://example.com/latest.json"],
+        pubkey: "",
+      },
+    },
+  };
+
+  assert.deepEqual(injectUpdaterPublicKey(config, encodedPublicKey), {
+    productName: "Pi Agent",
+    plugins: {
+      updater: {
+        endpoints: ["https://example.com/latest.json"],
+        pubkey: encodedPublicKey,
+      },
+    },
+  });
+  assert.equal(config.plugins.updater.pubkey, "");
+});
+
+test("writes the updater key into a Tauri configuration file", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pi-gui-updater-key-"));
+  const configPath = join(directory, "tauri.conf.json");
+
+  try {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        plugins: {
+          updater: {
+            endpoints: ["https://example.com/latest.json"],
+            pubkey: "",
+          },
+        },
+      }),
+    );
+
+    await configureUpdaterPublicKey({
+      publicKey: encodedPublicKey,
+      configPath,
+    });
+
+    const configured = JSON.parse(await readFile(configPath, "utf8"));
+    assert.equal(configured.plugins.updater.pubkey, encodedPublicKey);
+    assert.deepEqual(configured.plugins.updater.endpoints, [
+      "https://example.com/latest.json",
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed

- Validate `TAURI_UPDATER_PUBLIC_KEY` before installing build dependencies.
- Inject the validated public key into `plugins.updater.pubkey` in the CI workspace before Tauri bundles and signs updater artifacts.
- Keep the existing compile-time key injection used by the runtime updater plugin.
- Document the exact `.pub` file format and add focused validation/configuration tests.

## Root cause

The release workflow provided the public key only as `PI_GUI_UPDATER_PUBLIC_KEY`, which embeds it in the Rust application at compile time. Tauri's bundler independently reads `plugins.updater.pubkey` while signing updater archives; that config value remained empty, so both macOS builds failed after bundling with `Missing comment in public key`.

## Impact

Release jobs now fail quickly for missing or malformed public keys and provide the validated key to both the bundler and runtime updater without committing or printing it.

## Verification

- `node --test lib/*.test.mjs scripts/*.test.mjs` — 116 passed
- `node_modules/.bin/tsc --noEmit` — passed
- `npm run lint` — passed
- `npm run release:verify` — verified pi-gui 0.1.1, pi 0.81.1, pi-web 0.8.0
- `git diff --check` — passed
