### PR TITLE
Rename project to pi-agent-desktop

### DIFF
--- a/.github/workflows/component-updates.yml
+++ b/.github/workflows/component-updates.yml
@@ -17,7 +17,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out pi-gui
+      - name: Check out pi-agent-desktop
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
             fi
           fi
 
-          node scripts/bump-pi-gui-version.mjs
+          node scripts/bump-pi-agent-desktop-version.mjs
           npm run release:manifest
           node --test lib/*.test.mjs scripts/*.test.mjs
           node_modules/.bin/tsc --noEmit
@@ -89,9 +89,9 @@ jobs:
               --base "$GITHUB_REF_NAME" \
               --head codex/component-updates \
               --title "chore: sync released pi components" \
-              --body "Automated weekly sync of the latest stable pi and pi-web GitHub Releases. Merge this PR to make the complete signed pi-gui update available."
+              --body "Automated weekly sync of the latest stable pi and pi-web GitHub Releases. Merge this PR to make the complete signed pi-agent-desktop update available."
           else
             gh pr edit "$existing_pr" \
               --title "chore: sync released pi components" \
-              --body "Automated weekly sync of the latest stable pi and pi-web GitHub Releases. Merge this PR to make the complete signed pi-gui update available."
+              --body "Automated weekly sync of the latest stable pi and pi-web GitHub Releases. Merge this PR to make the complete signed pi-agent-desktop update available."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths:
-      - src-tauri/pi-gui-package.json
+      - src-tauri/pi-agent-desktop-package.json
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: pi-gui-release
+  group: pi-agent-desktop-release
   cancel-in-progress: false
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
             target: x86_64-apple-darwin
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Check out pi-gui
+      - name: Check out pi-agent-desktop
         uses: actions/checkout@v4
 
       - name: Require updater signing secrets
@@ -67,14 +67,14 @@ jobs:
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          PI_GUI_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
+          PI_AGENT_DESKTOP_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_SIGNING_IDENTITY: "-"
         with:
           tagName: v__VERSION__
-          releaseName: pi-gui v__VERSION__
-          releaseBody: A signed Pi Agent desktop release containing the latest verified pi-gui, pi, and pi-web components.
+          releaseName: pi-agent-desktop v__VERSION__
+          releaseBody: A signed Pi Agent desktop release containing the latest verified pi-agent-desktop, pi, and pi-web components.
           releaseDraft: true
           prerelease: false
           uploadUpdaterJson: true
@@ -84,13 +84,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Check out pi-gui
+      - name: Check out pi-agent-desktop
         uses: actions/checkout@v4
 
       - name: Upload component manifest to the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="$(node -p "require('./src-tauri/pi-gui-package.json').version")"
+          version="$(node -p "require('./src-tauri/pi-agent-desktop-package.json').version")"
           gh release upload "v$version" src-tauri/resources/component-versions.json --clobber
           gh release edit "v$version" --draft=false --latest

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pi Agent
 
-`pi-gui` 是一个面向 macOS 的本地 AI Agent 桌面应用。它将 [pi](https://github.com/earendil-works/pi) 的 Agent 能力、[pi-web](https://github.com/agegr/pi-web) 的 Web 界面与本仓库的桌面封装、品牌和升级逻辑组合为一个可独立安装的 App，产品界面统一使用 **Pi Agent** 名称。
+`pi-agent-desktop` 是一个面向 macOS 的本地 AI Agent 桌面应用。它将 [pi](https://github.com/earendil-works/pi) 的 Agent 能力、[pi-web](https://github.com/agegr/pi-web) 的 Web 界面与本仓库的桌面封装、品牌和升级逻辑组合为一个可独立安装的 App，产品界面统一使用 **Pi Agent** 名称。
 
-项目仓库：[abcwyc/pi-gui](https://github.com/abcwyc/pi-gui) · [Releases](https://github.com/abcwyc/pi-gui/releases)
+项目仓库：[abcwyc/pi-agent-desktop](https://github.com/abcwyc/pi-agent-desktop) · [Releases](https://github.com/abcwyc/pi-agent-desktop/releases)
 
 ## 项目组成
 
@@ -10,7 +10,7 @@ Pi Agent 由三个开源项目共同组成：
 
 | 组件 | 仓库 | 在 App 中的职责 |
 | --- | --- | --- |
-| `pi-gui` | [abcwyc/pi-gui](https://github.com/abcwyc/pi-gui) | macOS 桌面封装、Pi Agent 品牌、设置界面、版本管理和整包升级 |
+| `pi-agent-desktop` | [abcwyc/pi-agent-desktop](https://github.com/abcwyc/pi-agent-desktop) | macOS 桌面封装、Pi Agent 品牌、设置界面、版本管理和整包升级 |
 | `pi` | [earendil-works/pi](https://github.com/earendil-works/pi) | AgentSession、模型调用、工具执行、会话与配置能力 |
 | `pi-web` | [agegr/pi-web](https://github.com/agegr/pi-web) | Web UI、会话浏览、聊天交互、模型、Skills、Plugins 和文件预览 |
 
@@ -32,7 +32,7 @@ Pi Agent 由三个开源项目共同组成：
 
 ### 安装 macOS App
 
-发布版本可从 [GitHub Releases](https://github.com/abcwyc/pi-gui/releases) 下载：
+发布版本可从 [GitHub Releases](https://github.com/abcwyc/pi-agent-desktop/releases) 下载：
 
 1. 根据 Mac 架构下载 Apple Silicon 或 Intel 版本的 `.dmg`。
 2. 打开 DMG，将 App 拖入 `Applications`。
@@ -66,21 +66,21 @@ Pi Agent 默认读取 Pi 的本地数据目录：
 
 Pi Agent 最多每七天检查一次以下仓库的最新稳定 Release：
 
-- `abcwyc/pi-gui`
+- `abcwyc/pi-agent-desktop`
 - `earendil-works/pi`
 - `agegr/pi-web`
 
 版本与升级规则如下：
 
-1. `pi-gui` 一旦存在 Release，就以最新稳定 Release 作为可升级版本来源。
+1. `pi-agent-desktop` 一旦存在 Release，就以最新稳定 Release 作为可升级版本来源。
 2. 三个组件中任意一个版本落后，设置中的统一升级按钮都会启用。
-3. 如果多个组件需要更新，发布自动化按 `pi → pi-web → pi-gui` 的顺序同步和验证。
+3. 如果多个组件需要更新，发布自动化按 `pi → pi-web → pi-agent-desktop` 的顺序同步和验证。
 4. 用户侧不会修改已安装 App 内的单个 JavaScript 包，而是下载一个同时包含三个最新版组件的完整签名 App。
 5. 安装完成后 App 自动重启，使三个组件一次性进入同一个经过验证的发布状态。
 
 这种方式可以保持 macOS App 的代码签名和组件一致性，也能避免独立替换 `pi` 或 `pi-web` 导致运行时不兼容。
 
-如果上游新版已经被检测到，但包含该版本的签名 `pi-gui` Release 尚未发布，设置页会提示暂时没有可安装的签名整包；App 不会退回到下载未签名文件或局部覆盖依赖。
+如果上游新版已经被检测到，但包含该版本的签名 `pi-agent-desktop` Release 尚未发布，设置页会提示暂时没有可安装的签名整包；App 不会退回到下载未签名文件或局部覆盖依赖。
 
 更完整的同步、签名和 Release 配置见 [桌面升级与发布说明](./docs/desktop-updates.md)。
 
@@ -189,6 +189,6 @@ src-tauri/
 
 ## 署名与许可证
 
-Pi Agent 的桌面集成由 `pi-gui` 提供，核心能力和 Web 界面分别来自 [earendil-works/pi](https://github.com/earendil-works/pi) 与 [agegr/pi-web](https://github.com/agegr/pi-web)。感谢这些项目及其贡献者。
+Pi Agent 的桌面集成由 `pi-agent-desktop` 提供，核心能力和 Web 界面分别来自 [earendil-works/pi](https://github.com/earendil-works/pi) 与 [agegr/pi-web](https://github.com/agegr/pi-web)。感谢这些项目及其贡献者。
 
 本仓库根目录代码遵循 [`LICENSE`](./LICENSE) 中的 MIT License。三个组成项目的代码和依赖同时受各自仓库许可证约束；复制、修改或重新分发时请保留相应版权与许可声明。

--- a/components/AppSettings.tsx
+++ b/components/AppSettings.tsx
@@ -63,7 +63,7 @@ export function AppSettings({ onClose }: { onClose: () => void }) {
   }, [onClose, upgradeProgress]);
 
   const appRelease = useMemo(
-    () => components.find((component) => component.project === "pi-gui"),
+    () => components.find((component) => component.project === "pi-agent-desktop"),
     [components],
   );
   const pendingUpdates = useMemo(
@@ -95,7 +95,7 @@ export function AppSettings({ onClose }: { onClose: () => void }) {
       if (!result.installed) {
         setUpgradeProgress(null);
         setUpgradeError(
-          "The component updates are detected, but a signed pi-gui bundle containing them has not been published yet.",
+          "The component updates are detected, but a signed pi-agent-desktop bundle containing them has not been published yet.",
         );
       }
     } catch (error) {
@@ -238,7 +238,7 @@ export function AppSettings({ onClose }: { onClose: () => void }) {
                 <div style={{ minWidth: 74 }}>
                   <div style={{ color: "var(--text-dim)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.06em" }}>Bundled</div>
                   <div style={{ marginTop: 3, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
-                    v{component.project === "pi-gui" ? APP_VERSION_DISPLAY : component.currentVersion}
+                    v{component.project === "pi-agent-desktop" ? APP_VERSION_DISPLAY : component.currentVersion}
                   </div>
                 </div>
                 <div style={{ minWidth: 84 }}>

--- a/docs/desktop-updates.md
+++ b/docs/desktop-updates.md
@@ -1,12 +1,12 @@
 # Desktop release updates
 
-`pi-gui` updates the installed macOS app as one signed, atomic bundle. The bundle records the exact versions of all three components in `src-tauri/resources/component-versions.json`:
+`pi-agent-desktop` updates the installed macOS app as one signed, atomic bundle. The bundle records the exact versions of all three components in `src-tauri/resources/component-versions.json`:
 
-1. `abcwyc/pi-gui`
+1. `abcwyc/pi-agent-desktop`
 2. `earendil-works/pi`
 3. `agegr/pi-web`
 
-The settings screen checks the three repositories' latest stable GitHub Releases once a week. If any bundled version is older, its single **Upgrade** button downloads the newest signed `pi-gui` release, installs the complete app, and restarts it. It never replaces JavaScript or dependencies inside an already installed signed app.
+The settings screen checks the three repositories' latest stable GitHub Releases once a week. If any bundled version is older, its single **Upgrade** button downloads the newest signed `pi-agent-desktop` release, installs the complete app, and restarts it. It never replaces JavaScript or dependencies inside an already installed signed app.
 
 ## Weekly component sync
 
@@ -14,7 +14,7 @@ The settings screen checks the three repositories' latest stable GitHub Releases
 
 1. update all `@earendil-works/pi-*` packages to the released `pi` version;
 2. merge the released `pi-web` tag;
-3. bump `pi-gui`, regenerate the component manifest, and run tests, typecheck, and lint;
+3. bump `pi-agent-desktop`, regenerate the component manifest, and run tests, typecheck, and lint;
 4. open or refresh `codex/component-updates` as a reviewable pull request.
 
 Merge that pull request only after reviewing any upstream conflicts or UI changes.
@@ -26,7 +26,7 @@ The repository must allow GitHub Actions to create pull requests. If that settin
 Tauri updater signatures are mandatory. Generate the updater signing key once on a trusted machine:
 
 ```bash
-npm exec tauri signer generate -- -w ~/.tauri/pi-gui.key
+npm exec tauri signer generate -- -w ~/.tauri/pi-agent-desktop.key
 ```
 
 Store these repository Actions secrets:
@@ -39,6 +39,6 @@ Never commit the private key or its password. The public key is embedded at comp
 
 ## Publishing
 
-Merging a component sync pull request changes `src-tauri/pi-gui-package.json` and automatically starts **Publish signed macOS release**. It can also be started manually. The workflow verifies that the bundled `pi` and `pi-web` versions exactly match their latest stable Releases, then sequentially creates Apple Silicon and Intel app artifacts so their shared `latest.json` cannot race. The Release stays in draft until both signed updater archives and the component manifest are present; only then is `v<pi-gui version>` published as the latest Release.
+Merging a component sync pull request changes `src-tauri/pi-agent-desktop-package.json` and automatically starts **Publish signed macOS release**. It can also be started manually. The workflow verifies that the bundled `pi` and `pi-web` versions exactly match their latest stable Releases, then sequentially creates Apple Silicon and Intel app artifacts so their shared `latest.json` cannot race. The Release stays in draft until both signed updater archives and the component manifest are present; only then is `v<pi-agent-desktop version>` published as the latest Release.
 
 The workflow currently uses ad-hoc macOS application signing. Before distributing outside a controlled environment, configure an Apple Developer ID certificate and notarization in the release workflow as well.

--- a/docs/desktop.zh-CN.md
+++ b/docs/desktop.zh-CN.md
@@ -40,7 +40,7 @@ src-tauri/target/release/bundle/dmg/Pi Agent_<version>_<arch>.dmg
 
 构建结果是当前机器架构的原生应用：Apple Silicon 构建 `aarch64`，Intel Mac 构建 `x86_64`。发布给其他用户前，应使用 Apple Developer ID 签名并公证；本地开发和测试不要求签名。
 
-桌面版会检查 `pi-gui`、Pi 与 Pi Web 的官方 GitHub Release。每个项目最多每 7 天检查一次；发现任一组件有新版后，用户可以从设置中安装包含全部最新组件的完整签名 App 并重启。详细机制见 [桌面升级与发布说明](./desktop-updates.md)。
+桌面版会检查 `pi-agent-desktop`、Pi 与 Pi Web 的官方 GitHub Release。每个项目最多每 7 天检查一次；发现任一组件有新版后，用户可以从设置中安装包含全部最新组件的完整签名 App 并重启。详细机制见 [桌面升级与发布说明](./desktop-updates.md)。
 
 ## 运行日志
 

--- a/docs/release-v0.1.md
+++ b/docs/release-v0.1.md
@@ -2,7 +2,7 @@
 
 Pi Agent v0.1 是首个 macOS 预览版本。
 
-它将 [pi](https://github.com/earendil-works/pi) 的 Agent 能力与 [pi-web](https://github.com/agegr/pi-web) 的 Web 交互界面封装为一个可独立安装的桌面 App，并由 [pi-gui](https://github.com/abcwyc/pi-gui) 提供 macOS 集成、产品品牌、设置和版本升级能力。
+它将 [pi](https://github.com/earendil-works/pi) 的 Agent 能力与 [pi-web](https://github.com/agegr/pi-web) 的 Web 交互界面封装为一个可独立安装的桌面 App，并由 [pi-agent-desktop](https://github.com/abcwyc/pi-agent-desktop) 提供 macOS 集成、产品品牌、设置和版本升级能力。
 
 > 设置界面显示版本 `0.1`，内部语义化版本为 `0.1.0`。
 
@@ -13,7 +13,7 @@ Pi Agent v0.1 是首个 macOS 预览版本。
 - **完整 Agent 工作区**：支持历史会话、实时聊天、工具调用、上下文与成本查看、会话分支和 Fork。
 - **项目文件浏览**：可以浏览项目文件、切换 Git worktree，并预览源码、Diff、Markdown、图片、音频、PDF 和 DOCX。
 - **模型与扩展配置**：支持模型管理、OAuth/API Key、自定义模型、Skills 和 Plugins。
-- **版本设置页**：通过齿轮入口查看 `pi-gui`、`pi` 和 `pi-web` 的项目署名、当前打包版本及 GitHub Release 版本。
+- **版本设置页**：通过齿轮入口查看 `pi-agent-desktop`、`pi` 和 `pi-web` 的项目署名、当前打包版本及 GitHub Release 版本。
 - **每周更新提醒**：最多每七天检查一次三个组成项目的最新稳定 Release。
 - **统一整包升级**：任意组件有新版时，通过一个升级入口安装包含全部最新版组件的完整签名 App，避免局部替换依赖导致兼容性问题。
 
@@ -21,7 +21,7 @@ Pi Agent v0.1 是首个 macOS 预览版本。
 
 | 组件 | 版本 | 项目地址 |
 | --- | --- | --- |
-| `pi-gui` | `0.1.0` | [abcwyc/pi-gui](https://github.com/abcwyc/pi-gui) |
+| `pi-agent-desktop` | `0.1.0` | [abcwyc/pi-agent-desktop](https://github.com/abcwyc/pi-agent-desktop) |
 | `pi` | `0.81.1` | [earendil-works/pi](https://github.com/earendil-works/pi) |
 | `pi-web` | `0.7.17` | [agegr/pi-web](https://github.com/agegr/pi-web) |
 
@@ -56,7 +56,7 @@ Pi Agent v0.1 是首个 macOS 预览版本。
 
 v0.1 是自动升级能力的基线版本，因此旧测试包需要先手动安装由正式 Release 流水线生成并签名的本版本。完成首次安装后，后续版本可以在设置中检查并安装完整的 Pi Agent 更新。
 
-只有包含所需组件的签名 `pi-gui` Release 已发布时，App 才会执行安装；不会下载未签名文件，也不会直接覆盖已安装 App 内的单个依赖。
+只有包含所需组件的签名 `pi-agent-desktop` Release 已发布时，App 才会执行安装；不会下载未签名文件，也不会直接覆盖已安装 App 内的单个依赖。
 
 ## ⚠️ 已知限制
 
@@ -72,4 +72,4 @@ v0.1 是自动升级能力的基线版本，因此旧测试包需要先手动安
 - [agegr/pi-web](https://github.com/agegr/pi-web)
 - [Tauri](https://tauri.app/)
 
-Pi Agent 的桌面集成由 `pi-gui` 提供。各组成项目继续遵循各自仓库中的开源许可证。
+Pi Agent 的桌面集成由 `pi-agent-desktop` 提供。各组成项目继续遵循各自仓库中的开源许可证。

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -90,7 +90,7 @@ export interface PluginsResponse {
   diagnostics: PluginDiagnostic[];
 }
 
-export type AppUpdateProjectId = "pi-gui" | "pi" | "pi-web";
+export type AppUpdateProjectId = "pi-agent-desktop" | "pi" | "pi-web";
 
 export type AppReleaseStatus = "available" | "unpublished" | "unknown";
 

--- a/lib/app-updates.test.mjs
+++ b/lib/app-updates.test.mjs
@@ -82,9 +82,9 @@ test("does not report the installed release or prereleases", async () => {
 
 test("represents a repository without releases", async () => {
   const appProject = {
-    id: "pi-gui",
-    name: "pi-gui",
-    repository: "abcwyc/pi-gui",
+    id: "pi-agent-desktop",
+    name: "pi-agent-desktop",
+    repository: "abcwyc/pi-agent-desktop",
     currentVersion: "0.1",
   };
   const release = await getLatestAppRelease(appProject, {
@@ -92,10 +92,10 @@ test("represents a repository without releases", async () => {
   });
 
   assert.deepEqual(release, {
-    project: "pi-gui",
-    name: "pi-gui",
-    repository: "abcwyc/pi-gui",
-    repositoryUrl: "https://github.com/abcwyc/pi-gui",
+    project: "pi-agent-desktop",
+    name: "pi-agent-desktop",
+    repository: "abcwyc/pi-agent-desktop",
+    repositoryUrl: "https://github.com/abcwyc/pi-agent-desktop",
     currentVersion: "0.1",
     latestVersion: null,
     releaseUrl: null,
@@ -127,6 +127,6 @@ test("checks each project no more than once per week", () => {
   assert.equal(isAppUpdateDue(now - APP_UPDATE_CHECK_INTERVAL_MS, now), true);
   assert.equal(isAppUpdateDue(now + 1, now), true);
 
-  assert.equal(getNextAppUpdateCheckAt({ "pi-gui": now, pi: now, "pi-web": now }, now), now + APP_UPDATE_CHECK_INTERVAL_MS);
+  assert.equal(getNextAppUpdateCheckAt({ "pi-agent-desktop": now, pi: now, "pi-web": now }, now), now + APP_UPDATE_CHECK_INTERVAL_MS);
   assert.equal(getNextAppUpdateCheckAt({ pi: now }, now), now);
 });

--- a/lib/app-updates.ts
+++ b/lib/app-updates.ts
@@ -34,9 +34,9 @@ type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
 
 export const APP_UPDATE_PROJECTS: readonly AppUpdateProject[] = [
   {
-    id: "pi-gui",
+    id: "pi-agent-desktop",
     name: APP_DISTRIBUTION_NAME,
-    repository: "abcwyc/pi-gui",
+    repository: "abcwyc/pi-agent-desktop",
     currentVersion: APP_VERSION,
   },
   {
@@ -183,7 +183,7 @@ export async function getLatestAppRelease(
       headers: {
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": `pi-gui/${APP_VERSION}`,
+        "User-Agent": `pi-agent-desktop/${APP_VERSION}`,
       },
       signal: AbortSignal.timeout(options.timeoutMs ?? 15_000),
     },

--- a/lib/branding.test.mjs
+++ b/lib/branding.test.mjs
@@ -24,7 +24,7 @@ const userFacingFiles = [
 
 test("locks the local user-facing product name", () => {
   assert.equal(PRODUCT_NAME, "Pi Agent");
-  assert.equal(APP_DISTRIBUTION_NAME, "pi-gui");
+  assert.equal(APP_DISTRIBUTION_NAME, "pi-agent-desktop");
   assert.equal(APP_VERSION, "0.1.0");
   assert.equal(APP_VERSION_DISPLAY, "0.1");
   for (const relativePath of userFacingFiles) {

--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -6,10 +6,10 @@
  */
 export const PRODUCT_NAME = "Pi Agent" as const;
 
-import desktopPackage from "../src-tauri/pi-gui-package.json";
+import desktopPackage from "../src-tauri/pi-agent-desktop-package.json";
 
 /** Name and version of this packaged desktop distribution. */
-export const APP_DISTRIBUTION_NAME = "pi-gui" as const;
+export const APP_DISTRIBUTION_NAME = "pi-agent-desktop" as const;
 export const APP_VERSION = desktopPackage.version;
 export const APP_VERSION_DISPLAY = APP_VERSION.endsWith(".0")
   ? APP_VERSION.slice(0, -2)

--- a/scripts/bump-pi-agent-desktop-version.mjs
+++ b/scripts/bump-pi-agent-desktop-version.mjs
@@ -8,12 +8,12 @@ import {
   rootDir,
 } from "./release-components.mjs";
 
-const packagePath = join(rootDir, "src-tauri", "pi-gui-package.json");
+const packagePath = join(rootDir, "src-tauri", "pi-agent-desktop-package.json");
 const cargoPath = join(rootDir, "src-tauri", "Cargo.toml");
 const lockPath = join(rootDir, "src-tauri", "Cargo.lock");
 const desktopPackage = JSON.parse(await readFile(packagePath, "utf8"));
 const current = normalizeVersion(desktopPackage.version);
-const latest = await fetchLatestRelease("abcwyc/pi-gui", { allowMissing: true });
+const latest = await fetchLatestRelease("abcwyc/pi-agent-desktop", { allowMissing: true });
 const next = latest && compareVersions(latest.version, current) >= 0
   ? nextPatchVersion(latest.version)
   : current;
@@ -27,6 +27,6 @@ await writeFile(cargoPath, cargo.replace(/^(version\s*=\s*")[^"]+("\s*)$/m, `$1$
 const lock = await readFile(lockPath, "utf8");
 await writeFile(
   lockPath,
-  lock.replace(/(name = "pi-web-desktop"\nversion = ")[^"]+("\n)/, `$1${next}$2`),
+  lock.replace(/(name = "pi-agent-desktop"\nversion = ")[^"]+("\n)/, `$1${next}$2`),
 );
-console.log(`pi-gui ${current} -> ${next}`);
+console.log(`pi-agent-desktop ${current} -> ${next}`);

--- a/scripts/release-components.mjs
+++ b/scripts/release-components.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 export const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
 export const componentRepositories = {
-  "pi-gui": "abcwyc/pi-gui",
+  "pi-agent-desktop": "abcwyc/pi-agent-desktop",
   pi: "earendil-works/pi",
   "pi-web": "agegr/pi-web",
 };
@@ -62,19 +62,19 @@ async function readJson(path) {
 
 export async function readLocalComponentVersions() {
   const [desktopPackage, appPackage, piPackage, cargoManifest] = await Promise.all([
-    readJson(join(rootDir, "src-tauri", "pi-gui-package.json")),
+    readJson(join(rootDir, "src-tauri", "pi-agent-desktop-package.json")),
     readJson(join(rootDir, "package.json")),
     readJson(join(rootDir, "node_modules", "@earendil-works", "pi-coding-agent", "package.json")),
     readFile(join(rootDir, "src-tauri", "Cargo.toml"), "utf8"),
   ]);
   const cargoVersion = /^version\s*=\s*"([^"]+)"/m.exec(cargoManifest)?.[1];
   const versions = {
-    "pi-gui": normalizeVersion(desktopPackage.version),
+    "pi-agent-desktop": normalizeVersion(desktopPackage.version),
     pi: normalizeVersion(piPackage.version),
     "pi-web": normalizeVersion(appPackage.version),
   };
-  if (cargoVersion !== versions["pi-gui"]) {
-    throw new Error(`Cargo version ${cargoVersion ?? "missing"} does not match pi-gui ${versions["pi-gui"]}.`);
+  if (cargoVersion !== versions["pi-agent-desktop"]) {
+    throw new Error(`Cargo version ${cargoVersion ?? "missing"} does not match pi-agent-desktop ${versions["pi-agent-desktop"]}.`);
   }
   return versions;
 }
@@ -83,7 +83,7 @@ export async function fetchLatestRelease(repository, options = {}) {
   const headers = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "pi-gui-release-automation",
+    "User-Agent": "pi-agent-desktop-release-automation",
   };
   if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   const response = await (options.fetcher ?? fetch)(
@@ -104,19 +104,19 @@ export async function fetchLatestRelease(repository, options = {}) {
 }
 
 export async function readRemoteComponentVersions() {
-  const [piGui, pi, piWeb] = await Promise.all([
-    fetchLatestRelease(componentRepositories["pi-gui"], { allowMissing: true }),
+  const [piAgentDesktop, pi, piWeb] = await Promise.all([
+    fetchLatestRelease(componentRepositories["pi-agent-desktop"], { allowMissing: true }),
     fetchLatestRelease(componentRepositories.pi),
     fetchLatestRelease(componentRepositories["pi-web"]),
   ]);
-  return { "pi-gui": piGui, pi, "pi-web": piWeb };
+  return { "pi-agent-desktop": piAgentDesktop, pi, "pi-web": piWeb };
 }
 
 export function createComponentManifest(versions) {
   return {
     schemaVersion: 1,
-    appVersion: versions["pi-gui"],
-    components: ["pi-gui", "pi", "pi-web"].map((id) => ({
+    appVersion: versions["pi-agent-desktop"],
+    components: ["pi-agent-desktop", "pi", "pi-web"].map((id) => ({
       id,
       repository: componentRepositories[id],
       version: versions[id],

--- a/scripts/release-components.test.mjs
+++ b/scripts/release-components.test.mjs
@@ -27,12 +27,12 @@ test("bumps the patch version", () => {
 
 test("writes an auditable three-component manifest", () => {
   assert.deepEqual(
-    createComponentManifest({ "pi-gui": "0.1.0", pi: "0.81.1", "pi-web": "0.7.17" }),
+    createComponentManifest({ "pi-agent-desktop": "0.1.0", pi: "0.81.1", "pi-web": "0.7.17" }),
     {
       schemaVersion: 1,
       appVersion: "0.1.0",
       components: [
-        { id: "pi-gui", repository: "abcwyc/pi-gui", version: "0.1.0" },
+        { id: "pi-agent-desktop", repository: "abcwyc/pi-agent-desktop", version: "0.1.0" },
         { id: "pi", repository: "earendil-works/pi", version: "0.81.1" },
         { id: "pi-web", repository: "agegr/pi-web", version: "0.7.17" },
       ],

--- a/scripts/resolve-component-releases.mjs
+++ b/scripts/resolve-component-releases.mjs
@@ -16,7 +16,7 @@ const result = {
   pi_web_version: remote["pi-web"].version,
   pi_web_tag: remote["pi-web"].tag,
   pi_web_update: String(piWebUpdate),
-  pi_gui_latest: remote["pi-gui"]?.version ?? "",
+  pi_agent_desktop_latest: remote["pi-agent-desktop"]?.version ?? "",
   needs_update: String(piUpdate || piWebUpdate),
 };
 

--- a/scripts/verify-release-components.mjs
+++ b/scripts/verify-release-components.mjs
@@ -17,8 +17,13 @@ if (compareVersions(local.pi, remote.pi.version) !== 0) {
 if (compareVersions(local["pi-web"], remote["pi-web"].version) !== 0) {
   problems.push(`pi-web is ${local["pi-web"]}; latest Release is ${remote["pi-web"].version}`);
 }
-if (remote["pi-gui"] && compareVersions(local["pi-gui"], remote["pi-gui"].version) < 0) {
-  problems.push(`pi-gui is ${local["pi-gui"]}; latest Release is ${remote["pi-gui"].version}`);
+if (
+  remote["pi-agent-desktop"]
+  && compareVersions(local["pi-agent-desktop"], remote["pi-agent-desktop"].version) < 0
+) {
+  problems.push(
+    `pi-agent-desktop is ${local["pi-agent-desktop"]}; latest Release is ${remote["pi-agent-desktop"].version}`,
+  );
 }
 
 const expectedManifest = createComponentManifest(local);
@@ -33,4 +38,6 @@ if (JSON.stringify(actualManifest) !== JSON.stringify(expectedManifest)) {
 if (problems.length > 0) {
   throw new Error(`Release verification failed:\n- ${problems.join("\n- ")}`);
 }
-console.log(`Verified pi-gui ${local["pi-gui"]}, pi ${local.pi}, pi-web ${local["pi-web"]}.`);
+console.log(
+  `Verified pi-agent-desktop ${local["pi-agent-desktop"]}, pi ${local.pi}, pi-web ${local["pi-web"]}.`,
+);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2254,7 +2254,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pi-web-desktop"
+name = "pi-agent-desktop"
 version = "0.1.0"
 dependencies = [
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "pi-web-desktop"
+name = "pi-agent-desktop"
 version = "0.1.0"
 description = "macOS desktop shell for Pi Agent"
-authors = ["pi-gui contributors"]
+authors = ["pi-agent-desktop contributors"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.85.0"
 
 [lib]
-name = "pi_web_desktop_lib"
+name = "pi_agent_desktop_lib"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [build-dependencies]

--- a/src-tauri/capabilities/desktop-updater.json
+++ b/src-tauri/capabilities/desktop-updater.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "desktop-updater",
-  "description": "Allow the packaged local Pi Agent UI to install signed pi-gui releases.",
+  "description": "Allow the packaged local Pi Agent UI to install signed pi-agent-desktop releases.",
   "windows": ["main"],
   "remote": {
     "urls": ["http://127.0.0.1:*/*"]

--- a/src-tauri/pi-agent-desktop-package.json
+++ b/src-tauri/pi-agent-desktop-package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pi-gui",
+  "name": "pi-agent-desktop",
   "version": "0.1.0",
   "private": true
 }

--- a/src-tauri/resources/component-versions.json
+++ b/src-tauri/resources/component-versions.json
@@ -3,8 +3,8 @@
   "appVersion": "0.1.0",
   "components": [
     {
-      "id": "pi-gui",
-      "repository": "abcwyc/pi-gui",
+      "id": "pi-agent-desktop",
+      "repository": "abcwyc/pi-agent-desktop",
       "version": "0.1.0"
     },
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -260,7 +260,7 @@ pub fn run() {
             // The updater public key is embedded at compile time by the release
             // workflow. Local development builds intentionally omit it, which
             // keeps unsigned builds from accepting production updates.
-            if let Some(public_key) = option_env!("PI_GUI_UPDATER_PUBLIC_KEY")
+            if let Some(public_key) = option_env!("PI_AGENT_DESKTOP_UPDATER_PUBLIC_KEY")
                 .map(str::trim)
                 .filter(|key| !key.is_empty())
             {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    pi_web_desktop_lib::run();
+    pi_agent_desktop_lib::run();
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pi Agent",
-  "version": "pi-gui-package.json",
+  "version": "pi-agent-desktop-package.json",
   "identifier": "com.abcwyc.pi-agent",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -19,7 +19,7 @@
     "active": true,
     "targets": ["app", "dmg"],
     "category": "DeveloperTool",
-    "copyright": "Copyright © pi-gui contributors",
+    "copyright": "Copyright © pi-agent-desktop contributors",
     "shortDescription": "Desktop UI for the pi coding agent",
     "longDescription": "Pi Agent desktop app for browsing sessions and working with the local pi coding agent.",
     "icon": [
@@ -37,7 +37,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/abcwyc/pi-gui/releases/latest/download/latest.json"
+        "https://github.com/abcwyc/pi-agent-desktop/releases/latest/download/latest.json"
       ],
       "pubkey": ""
     }


### PR DESCRIPTION
## Summary

- Rename the desktop distribution and component ID from `pi-gui` to `pi-agent-desktop`.
- Update Tauri, Rust crate/lib names, updater configuration, release manifests, scripts, tests, and GitHub Actions workflows.
- Update repository links and project documentation to the renamed GitHub repository.

## Why

The GitHub repository has been renamed to `abcwyc/pi-agent-desktop`, so the application metadata and release automation need to use the same project identity consistently.

## Impact

The user-facing product name remains **Pi Agent**. Desktop package metadata, release checks, updater endpoints, CI publishing, and internal component identifiers now use `pi-agent-desktop`.

## Validation

- `node --test lib/*.test.mjs scripts/*.test.mjs` — 106 tests passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run release:manifest`
- GitHub Actions YAML parsed successfully
