### PR TITLE
Gate unattended pi-web syncs on the fork merge boundary

### DIFF
--- a/.github/workflows/component-updates.yml
+++ b/.github/workflows/component-updates.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   actions: write
   contents: write
+  pull-requests: write
+  issues: write
 
 concurrency:
   group: component-release-sync
@@ -38,12 +40,45 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/resolve-component-releases.mjs
 
-      - name: Synchronize released components into main
-        if: steps.releases.outputs.needs_update == 'true'
+      # A sync held for review keeps `needs_update` true until it is merged, so
+      # without this the job would redo the same work — and fail on the existing
+      # branch — every night while the PR sits open.
+      - name: Skip if this sync is already awaiting review
+        id: pending
+        if: steps.releases.outputs.pi_web_update == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          PI_VERSION: ${{ steps.releases.outputs.pi_version }}
           PI_WEB_TAG: ${{ steps.releases.outputs.pi_web_tag }}
+        run: |
+          set -euo pipefail
+          open="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --head "sync/pi-web-$PI_WEB_TAG" --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$open" ]; then
+            echo "Sync for $PI_WEB_TAG is already open as PR #$open; nothing to do."
+            echo "awaiting_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "awaiting_review=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Classify BEFORE merging: once the merge commit exists the incoming
+      # changeset is no longer recoverable with a plain diff.
+      - name: Classify the upstream changeset against the fork boundary
+        id: boundary
+        if: steps.releases.outputs.pi_web_update == 'true' && steps.pending.outputs.awaiting_review != 'true'
+        env:
+          PI_WEB_TAG: ${{ steps.releases.outputs.pi_web_tag }}
+        run: |
+          set -euo pipefail
+          git remote add pi-web-upstream https://github.com/agegr/pi-web.git
+          git fetch --no-tags pi-web-upstream "refs/tags/$PI_WEB_TAG:refs/tags/pi-web-release"
+          base="$(git merge-base HEAD refs/tags/pi-web-release)"
+          git diff --name-only "$base" refs/tags/pi-web-release \
+            | node scripts/fork-ownership.mjs classify -
+
+      - name: Synchronize released components
+        if: steps.releases.outputs.needs_update == 'true' && steps.pending.outputs.awaiting_review != 'true'
+        env:
+          PI_VERSION: ${{ steps.releases.outputs.pi_version }}
           PI_UPDATE: ${{ steps.releases.outputs.pi_update }}
           PI_WEB_UPDATE: ${{ steps.releases.outputs.pi_web_update }}
         run: |
@@ -54,37 +89,114 @@ jobs:
           # When a pi-web merge is also pending, defer the pi install until after
           # the merge: installing first dirties the tree and git refuses to merge.
           if [ "$PI_UPDATE" = "true" ] && [ "$PI_WEB_UPDATE" != "true" ]; then
-            npm install --save-exact \
-              "@earendil-works/pi-agent-core@$PI_VERSION" \
-              "@earendil-works/pi-ai@$PI_VERSION" \
-              "@earendil-works/pi-coding-agent@$PI_VERSION" \
-              "@earendil-works/pi-tui@$PI_VERSION"
+            npm install --save-exact $(node scripts/pi-packages.mjs --install-spec "$PI_VERSION")
           fi
 
           if [ "$PI_WEB_UPDATE" = "true" ]; then
-            git remote add pi-web-upstream https://github.com/agegr/pi-web.git
-            git fetch --no-tags pi-web-upstream "refs/tags/$PI_WEB_TAG:refs/tags/pi-web-release"
+            # The tag was already fetched by the boundary classification step.
             git merge --no-edit --no-ff refs/tags/pi-web-release
             npm install
             if [ "$PI_UPDATE" = "true" ]; then
-              npm install --save-exact \
-                "@earendil-works/pi-agent-core@$PI_VERSION" \
-                "@earendil-works/pi-ai@$PI_VERSION" \
-                "@earendil-works/pi-coding-agent@$PI_VERSION" \
-                "@earendil-works/pi-tui@$PI_VERSION"
+              npm install --save-exact $(node scripts/pi-packages.mjs --install-spec "$PI_VERSION")
             fi
           fi
 
           node scripts/bump-pi-agent-desktop-version.mjs
           npm run release:manifest
-          node --test lib/*.test.mjs scripts/*.test.mjs
+
+      # A clean `git merge` is not evidence the two sides agree, so the gate has
+      # to be as wide as it can cheaply be. Component tests are included here
+      # deliberately: upstream ships them and they cover fork-modified files.
+      - name: Verify the merged tree
+        if: steps.releases.outputs.needs_update == 'true' && steps.pending.outputs.awaiting_review != 'true'
+        run: |
+          set -euo pipefail
+          npm test
           node_modules/.bin/tsc --noEmit
           npm run lint
+          # Build the standalone output the desktop app actually ships, so a
+          # broken bundle fails here rather than midway through a signed release.
+          PI_WEB_DESKTOP_BUILD=1 node_modules/.bin/next build --webpack
 
+      - name: Commit the sync
+        if: steps.releases.outputs.needs_update == 'true' && steps.pending.outputs.awaiting_review != 'true'
+        run: |
+          set -euo pipefail
           git add --all
           git commit -m "chore: sync released pi components"
+
+      # Upstream did not touch anything this fork has modified, so the merge
+      # cannot have produced a silent semantic conflict. Ship it.
+      - name: Publish unattended
+        if: steps.releases.outputs.needs_update == 'true' && steps.pending.outputs.awaiting_review != 'true' && steps.boundary.outputs.review_required != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
           git push origin HEAD:main
 
           # Pushes made with GITHUB_TOKEN do not trigger other push workflows,
           # so dispatch the signed release build explicitly after main updates.
           gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main
+
+      # Upstream changed files the fork has also rewritten. Git may have merged
+      # them cleanly and still be wrong, so a human reviews before anything is
+      # signed and published.
+      - name: Open a review PR
+        if: steps.releases.outputs.needs_update == 'true' && steps.pending.outputs.awaiting_review != 'true' && steps.boundary.outputs.review_required == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PI_WEB_TAG: ${{ steps.releases.outputs.pi_web_tag }}
+          HIGHEST_RISK: ${{ steps.boundary.outputs.highest_risk }}
+          BOUNDARY_REPORT: ${{ steps.boundary.outputs.report }}
+        run: |
+          set -euo pipefail
+          branch="sync/pi-web-$PI_WEB_TAG"
+          git push --force-with-lease origin "HEAD:refs/heads/$branch"
+
+          {
+            echo "Automated sync of \`$PI_WEB_TAG\`, held for review."
+            echo
+            echo "$BOUNDARY_REPORT"
+            echo
+            echo "Tests, \`tsc --noEmit\`, lint and the desktop build all passed —"
+            echo "that is exactly why this needs eyes. Check the listed files for"
+            echo "behaviour the merge kept from both sides."
+            echo
+            echo "Merging this PR to \`main\` triggers the signed release build."
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$branch" \
+            --title "chore: sync pi-web $PI_WEB_TAG (review required: $HIGHEST_RISK risk)" \
+            --body-file /tmp/pr-body.md
+
+      # Without this a failed sync is silent, and the fork quietly falls behind
+      # upstream until someone happens to look at the Actions tab.
+      - name: Report a failed sync
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --label component-sync-failure --limit 1 --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Sync failed again: $RUN_URL"
+          else
+            gh label create component-sync-failure --repo "$GITHUB_REPOSITORY" \
+              --color B60205 --description "Automated pi/pi-web sync needs attention" 2>/dev/null || true
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Component sync failed" \
+              --label component-sync-failure \
+              --body "The nightly pi/pi-web sync failed: $RUN_URL
+
+          Most likely a merge conflict against a file listed in \`scripts/fork-ownership.json\`.
+          See docs/ownership-boundaries.md for how to resolve it. This issue is reused for
+          subsequent failures — close it once the sync is green again."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ yarn-error.log*
 next-env.d.ts
 .factory
 
+# local agent tooling state
+/.claude/
+/.spec-workflow/
+
 # generated macOS desktop bundle inputs and Rust build output
 /src-tauri/gen/
 /src-tauri/resources/Pi Web Server.app/

--- a/README.md
+++ b/README.md
@@ -135,14 +135,17 @@ npm run desktop:dev
 ### 常用检查
 
 ```bash
-# Node 测试
-node --test lib/*.test.mjs scripts/*.test.mjs
+# Node 测试（与 CI 同步门禁完全一致，含 components/ 测试）
+npm test
 
 # TypeScript
 node_modules/.bin/tsc --noEmit
 
 # ESLint 与品牌保护测试
 npm run lint
+
+# 与 pi-web 上游的偏离度：区分「样式类」与「结构类」改动
+npm run drift
 
 # Rust/Tauri
 cargo fmt --check --manifest-path src-tauri/Cargo.toml
@@ -171,12 +174,16 @@ npm run desktop:build
 
 ## 上游同步与 Release
 
-仓库包含两条串联的自动化工作流，更新过程只使用 `main`：
+仓库包含两条串联的自动化工作流：
 
-- [`component-updates.yml`](./.github/workflows/component-updates.yml)：每天检查 `pi` 和 `pi-web` 的稳定 Release；发现新版后直接更新 `main` 中的依赖、合并 `pi-web` Release Tag、更新组件清单并运行完整检查，成功后提交到 `main` 并触发发布。
+- [`component-updates.yml`](./.github/workflows/component-updates.yml)：每天检查 `pi` 和 `pi-web` 的稳定 Release。发现新版后，**先**把上游改动集与 [`scripts/fork-ownership.json`](./scripts/fork-ownership.json) 记录的「本仓库改过的上游文件」求交集，再合并 Tag、更新依赖和组件清单，并运行完整门禁（`npm test`、`tsc`、`lint`、真实 standalone 构建）。
+  - 交集为空 → 直接提交 `main` 并触发发布；
+  - 命中高/中风险文件 → 推送 `sync/pi-web-<tag>` 分支并开 PR，附上边界报告，**不**触发发布。合并该 PR 才会发版。
 - [`release.yml`](./.github/workflows/release.yml)：收到组件同步工作流的显式触发后，串行构建 Apple Silicon (`aarch64`) DMG 和 Windows x64 NSIS `-setup.exe`，仍不构建 Intel Mac 版本。Release 在两个平台的 updater 签名文件、`latest.json` 和组件清单全部上传完成前保持草稿状态。
 
-上游同步使用 Git 合并，因此本仓库维护的 Pi Agent 品牌、设置入口和升级逻辑会作为本地修改保留。如果上游与本地修改发生冲突，工作流会停止，必须审核和解决冲突后才能发布。
+上游同步使用 Git 合并，因此本仓库维护的 Pi Agent 品牌、设置入口和升级逻辑会作为本地修改保留。合并冲突会让工作流停止——这是安全的失败方式。真正危险的是**无冲突但语义错误**的合并：上游改了本仓库也改过的区域，Git 干净地合上了，测试也全绿。上面的边界求交就是为此设置的，规则见 [维护边界说明](./docs/ownership-boundaries.md)。
+
+同步失败会自动创建/更新 `component-sync-failure` Issue，不会静默积压。
 
 正式发布前需要配置：
 
@@ -203,6 +210,7 @@ instrumentation.ts     Next.js 服务端 HTTP 代理初始化
 
 ## 相关文档
 
+- [维护边界说明](./docs/ownership-boundaries.md) — 与 `pi-web` 上游的分工、改共享文件的规则、自动同步的判定逻辑
 - [桌面升级与发布说明](./docs/desktop-updates.md)
 - [Git Worktree 使用说明](./docs/worktrees.zh-CN.md)
 - [Pi Session 与项目架构说明](./AGENTS.md)

--- a/app/api/updates/route.ts
+++ b/app/api/updates/route.ts
@@ -16,7 +16,7 @@ import type {
   AppUpdateInfo,
   AppUpdateProjectId,
   AppUpdatesResponse,
-} from "@/lib/api-types";
+} from "@/lib/app-update-types";
 
 export const dynamic = "force-dynamic";
 

--- a/components/AppSettings.tsx
+++ b/components/AppSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
-import type { AppComponentReleaseInfo, AppUpdatesResponse } from "@/lib/api-types";
+import type { AppComponentReleaseInfo, AppUpdatesResponse } from "@/lib/app-update-types";
 import {
   APP_DISTRIBUTION_NAME,
   APP_VERSION_DISPLAY,

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -20,15 +20,7 @@ import { getFileName } from "@/lib/file-paths";
 import { buildAtMentionText, buildFileAtMentionsText, buildFileLineMentionText } from "@/lib/file-fuzzy";
 import { PRODUCT_NAME } from "@/lib/branding";
 import { getInitialNavigation } from "@/lib/initial-navigation";
-import { isTauriDesktop } from "@/lib/desktop-updater";
-import {
-  getDesktopPlatform,
-  minimizeWindow,
-  toggleMaximizeWindow,
-  closeWindow,
-  isWindowMaximized,
-  type DesktopPlatform,
-} from "@/lib/desktop-window";
+import { WindowControls, useDesktopChrome } from "./desktop";
 import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ChatInputHandle } from "./ChatInput";
 import type { SessionStatsInfo } from "@/lib/pi-types";
@@ -63,19 +55,10 @@ export function AppShell() {
   const [appSettingsOpen, setAppSettingsOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileSidebarReady, setMobileSidebarReady] = useState(false);
-  // The desktop window has no native title bar; macOS keeps the traffic
-  // lights (we only inset content for them), other platforms need custom
-  // minimize/maximize/close buttons drawn into the top bar instead.
-  const [desktopPlatform, setDesktopPlatform] = useState<DesktopPlatform>(null);
-  const [windowMaximized, setWindowMaximized] = useState(false);
-  useEffect(() => {
-    if (!isTauriDesktop()) return;
-    setDesktopPlatform(getDesktopPlatform());
-    const refreshMaximized = () => { isWindowMaximized().then(setWindowMaximized); };
-    refreshMaximized();
-    window.addEventListener("resize", refreshMaximized);
-    return () => window.removeEventListener("resize", refreshMaximized);
-  }, []);
+  // The desktop window has no native title bar. macOS keeps its traffic lights
+  // and only needs the top bar inset for them; other platforms get the buttons
+  // from <WindowControls />, which renders nothing in a browser build.
+  const desktopChrome = useDesktopChrome();
   // On mobile the sidebar is an overlay drawer; hide it by default so the chat
   // is visible on load. Runs once the breakpoint resolves after hydration.
   useEffect(() => {
@@ -667,8 +650,8 @@ export function AppShell() {
         {/* Top bar with sidebar toggle */}
         <div
           ref={topBarRef}
-          className={`app-topbar${desktopPlatform === "macos" && (!sidebarOpen || isMobile) ? " app-topbar--mac-inset" : ""}`}
-          data-tauri-drag-region={desktopPlatform ? true : undefined}
+          className={`app-topbar${desktopChrome.isMacOS && (!sidebarOpen || isMobile) ? " app-topbar--mac-inset" : ""}`}
+          {...desktopChrome.dragRegionProps}
           style={{ display: "flex", alignItems: "center", flexShrink: 0, borderBottom: "1px solid var(--border)", height: 36, background: "var(--bg-panel)" }}
         >
           <button
@@ -1157,47 +1140,7 @@ export function AppShell() {
             </div>
           )}
 
-          {desktopPlatform && desktopPlatform !== "macos" && (
-            <div className="window-controls">
-              <button
-                type="button"
-                className="window-control-btn"
-                aria-label="Minimize"
-                onClick={() => { void minimizeWindow(); }}
-              >
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
-                  <line x1="0" y1="5" x2="10" y2="5" />
-                </svg>
-              </button>
-              <button
-                type="button"
-                className="window-control-btn"
-                aria-label={windowMaximized ? "Restore" : "Maximize"}
-                onClick={async () => { await toggleMaximizeWindow(); setWindowMaximized(await isWindowMaximized()); }}
-              >
-                {windowMaximized ? (
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
-                    <rect x="2" y="0.5" width="7.5" height="7.5" />
-                    <path d="M0.5 2.5 V9.5 H7.5" />
-                  </svg>
-                ) : (
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
-                    <rect x="0.5" y="0.5" width="9" height="9" />
-                  </svg>
-                )}
-              </button>
-              <button
-                type="button"
-                className="window-control-btn window-control-btn--close"
-                aria-label="Close"
-                onClick={() => { void closeWindow(); }}
-              >
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
-                  <line x1="0" y1="0" x2="10" y2="10" /><line x1="10" y1="0" x2="0" y2="10" />
-                </svg>
-              </button>
-            </div>
-          )}
+          <WindowControls />
         </div>
 
         {/* Chat content */}

--- a/components/UpdateReminder.tsx
+++ b/components/UpdateReminder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { AppUpdateInfo, AppUpdatesResponse } from "@/lib/api-types";
+import type { AppUpdateInfo, AppUpdatesResponse } from "@/lib/app-update-types";
 import { PRODUCT_NAME } from "@/lib/branding";
 
 const RETRY_AFTER_ERROR_MS = 6 * 60 * 60 * 1000;

--- a/components/desktop/WindowControls.tsx
+++ b/components/desktop/WindowControls.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { isTauriDesktop } from "@/lib/desktop-updater";
+import {
+  closeWindow,
+  isWindowMaximized,
+  minimizeWindow,
+  toggleMaximizeWindow,
+} from "@/lib/desktop-window";
+
+import { useDesktopChrome } from "./useDesktopChrome";
+
+/**
+ * Minimize / maximize / close buttons for a frameless desktop window.
+ *
+ * Renders nothing in the browser, and nothing on macOS either — there the
+ * native traffic lights stay visible and the top bar just insets around them.
+ * Self-contained on purpose: the host only has to mount it, so upstream layout
+ * files carry a single line instead of the state, effects and icons.
+ */
+export function WindowControls() {
+  const { isDesktop, isMacOS } = useDesktopChrome();
+  const [maximized, setMaximized] = useState(false);
+  const drawsOwnControls = isDesktop && !isMacOS;
+
+  useEffect(() => {
+    if (!isTauriDesktop() || !drawsOwnControls) return;
+
+    const refresh = () => { void isWindowMaximized().then(setMaximized); };
+    refresh();
+    window.addEventListener("resize", refresh);
+    return () => window.removeEventListener("resize", refresh);
+  }, [drawsOwnControls]);
+
+  const handleToggleMaximize = useCallback(async () => {
+    await toggleMaximizeWindow();
+    setMaximized(await isWindowMaximized());
+  }, []);
+
+  if (!drawsOwnControls) return null;
+
+  return (
+    <div className="window-controls">
+      <button
+        type="button"
+        className="window-control-btn"
+        aria-label="Minimize"
+        onClick={() => { void minimizeWindow(); }}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
+          <line x1="0" y1="5" x2="10" y2="5" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="window-control-btn"
+        aria-label={maximized ? "Restore" : "Maximize"}
+        onClick={() => { void handleToggleMaximize(); }}
+      >
+        {maximized ? (
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
+            <rect x="2" y="0.5" width="7.5" height="7.5" />
+            <path d="M0.5 2.5 V9.5 H7.5" />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
+            <rect x="0.5" y="0.5" width="9" height="9" />
+          </svg>
+        )}
+      </button>
+      <button
+        type="button"
+        className="window-control-btn window-control-btn--close"
+        aria-label="Close"
+        onClick={() => { void closeWindow(); }}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
+          <line x1="0" y1="0" x2="10" y2="10" /><line x1="10" y1="0" x2="0" y2="10" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/components/desktop/desktop-chrome.test.mjs
+++ b/components/desktop/desktop-chrome.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { dirname } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createJiti } from "jiti";
+
+/**
+ * The window chrome moved out of AppShell.tsx, which used these expressions
+ * inline:
+ *
+ *   className={`app-topbar${desktopPlatform === "macos" && … }`}
+ *   data-tauri-drag-region={desktopPlatform ? true : undefined}
+ *   {desktopPlatform && desktopPlatform !== "macos" && ( …buttons… )}
+ *
+ * The extraction replaced them with `isMacOS`, `dragRegionProps` and
+ * `isDesktop && !isMacOS`. These tests pin that equivalence for every platform
+ * value, so a refactor cannot quietly change which chrome a platform gets.
+ */
+
+// The real implementation, not a restatement of it — a copy would keep passing
+// after someone changed the source. The alias mirrors tsconfig's "@/*" paths,
+// which jiti does not read on its own.
+const rootDir = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const jiti = createJiti(import.meta.url, { alias: { "@": rootDir } });
+const { desktopChromeFor: chromeFor } = await jiti.import("./useDesktopChrome.ts");
+
+const PLATFORMS = ["macos", "windows", "linux", null];
+
+test("drag region matches the original data-tauri-drag-region expression", () => {
+  for (const platform of PLATFORMS) {
+    const legacy = platform ? true : undefined;
+    const actual = chromeFor(platform).dragRegionProps["data-tauri-drag-region"];
+    assert.equal(actual, legacy, `platform ${platform}`);
+  }
+});
+
+test("mac inset matches the original desktopPlatform === 'macos' expression", () => {
+  for (const platform of PLATFORMS) {
+    assert.equal(chromeFor(platform).isMacOS, platform === "macos", `platform ${platform}`);
+  }
+});
+
+test("custom window buttons render exactly where they used to", () => {
+  for (const platform of PLATFORMS) {
+    const legacy = Boolean(platform && platform !== "macos");
+    const chrome = chromeFor(platform);
+    assert.equal(chrome.isDesktop && !chrome.isMacOS, legacy, `platform ${platform}`);
+  }
+});
+
+test("a browser build gets no desktop chrome at all", () => {
+  const chrome = chromeFor(null);
+  assert.equal(chrome.isDesktop, false);
+  assert.equal(chrome.isMacOS, false);
+  assert.deepEqual(chrome.dragRegionProps, {});
+});
+
+test("macOS keeps its native traffic lights and draws no buttons", () => {
+  const chrome = chromeFor("macos");
+  assert.equal(chrome.isDesktop, true);
+  assert.equal(chrome.isMacOS, true);
+  assert.equal(chrome.isDesktop && !chrome.isMacOS, false);
+  assert.equal(chrome.dragRegionProps["data-tauri-drag-region"], true);
+});
+
+test("windows and linux draw their own buttons", () => {
+  for (const platform of ["windows", "linux"]) {
+    const chrome = chromeFor(platform);
+    assert.equal(chrome.isDesktop && !chrome.isMacOS, true, `platform ${platform}`);
+    assert.equal(chrome.dragRegionProps["data-tauri-drag-region"], true, `platform ${platform}`);
+  }
+});

--- a/components/desktop/index.ts
+++ b/components/desktop/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Desktop-only UI, kept out of the components agegr/pi-web owns.
+ *
+ * Upstream files should reach this directory through a single import and mount
+ * point. Anything here renders to nothing in a browser build, so the host does
+ * not need its own `isTauriDesktop()` branch around it.
+ *
+ * See docs/ownership-boundaries.md.
+ */
+
+export { WindowControls } from "./WindowControls";
+export { useDesktopChrome, type DesktopChrome } from "./useDesktopChrome";

--- a/components/desktop/useDesktopChrome.ts
+++ b/components/desktop/useDesktopChrome.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { isTauriDesktop } from "@/lib/desktop-updater";
+import { getDesktopPlatform, type DesktopPlatform } from "@/lib/desktop-window";
+
+export interface DesktopChrome {
+  /** OS family when running inside the packaged app, otherwise null. */
+  platform: DesktopPlatform;
+  /** True only in the Tauri shell — always false in a browser. */
+  isDesktop: boolean;
+  /** macOS keeps its native traffic lights, so the top bar insets instead of drawing controls. */
+  isMacOS: boolean;
+  /** Spread onto the element that should drag the frameless window. */
+  dragRegionProps: { "data-tauri-drag-region"?: true };
+}
+
+/**
+ * Pure platform-to-chrome mapping, kept separate from the hook so the branch
+ * conditions are testable without a React renderer.
+ */
+export function desktopChromeFor(platform: DesktopPlatform): DesktopChrome {
+  return {
+    platform,
+    isDesktop: platform !== null,
+    isMacOS: platform === "macos",
+    dragRegionProps: platform ? { "data-tauri-drag-region": true } : {},
+  };
+}
+
+/**
+ * Window-chrome facts for a shell that has no native title bar.
+ *
+ * Resolves after mount rather than during render: the server and the first
+ * client pass must agree, and `window.__TAURI_INTERNALS__` only exists in the
+ * browser. In a plain web build every field stays inert.
+ */
+export function useDesktopChrome(): DesktopChrome {
+  const [platform, setPlatform] = useState<DesktopPlatform>(null);
+
+  useEffect(() => {
+    if (!isTauriDesktop()) return;
+    setPlatform(getDesktopPlatform());
+  }, []);
+
+  return desktopChromeFor(platform);
+}

--- a/components/fork-extractions.test.mjs
+++ b/components/fork-extractions.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * Sentinels for fork changes inside upstream-owned components.
+ *
+ * A `git merge` conflict from agegr/pi-web is the safe outcome: the sync job
+ * fails and a human looks. These tests cover the unsafe outcome — a merge that
+ * succeeds cleanly and is still wrong, in either direction:
+ *
+ *   RESURRECTION  Code the fork moved to another file reappears at its origin.
+ *                 Git does not track cross-file moves, so an upstream edit to
+ *                 the moved region merges straight back in and the app ends up
+ *                 with two copies of the same behaviour.
+ *
+ *   EROSION       A fork change is dropped by the merge, silently reverting a
+ *                 desktop feature to its upstream form.
+ *
+ * Neither shows up in tsc, eslint, or the upstream test suite. See
+ * docs/ownership-boundaries.md; risk levels live in scripts/fork-ownership.json.
+ */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (file) => readFile(join(rootDir, file), "utf8");
+
+/** Source with import statements removed, so a re-import never reads as a definition. */
+function withoutImports(source) {
+  return source.replace(/^import\s[\s\S]*?from\s+["'][^"']+["'];?$/gm, "");
+}
+
+function definesSymbol(source, symbol) {
+  const body = withoutImports(source);
+  return new RegExp(
+    `(?:^|\\n)\\s*(?:export\\s+)?(?:async\\s+)?(?:function|class|const|let|var)\\s+${symbol}\\b`,
+  ).test(body);
+}
+
+const EXTRACTIONS = [
+  {
+    name: "SessionSidebar project picker",
+    origin: "components/SessionSidebar.tsx",
+    // Roughly 500 lines were moved out of SessionSidebar into these files,
+    // neither of which exists upstream. This is the highest-risk divergence in
+    // the fork; see the manifest entry for components/SessionSidebar.tsx.
+    movedTo: ["components/ProjectPicker.tsx", "components/path-ui.tsx"],
+    movedDefinitions: ["getRecentProjects", "displayCwd", "PathLabel", "AnimatedDropdown"],
+    // Project-picker internals that must live only in ProjectPicker now.
+    absentFromOrigin: [
+      "customPathOpen",
+      "customPathValidating",
+      "projectFilter",
+      "/api/cwd/validate",
+      "/api/default-cwd",
+    ],
+    requiredInOrigin: ["ProjectPicker"],
+  },
+];
+
+const FORK_FEATURES = [
+  {
+    name: "AppShell desktop chrome",
+    file: "components/AppShell.tsx",
+    markers: [
+      "isTauriDesktop",
+      "getDesktopPlatform",
+      "toggleMaximizeWindow",
+      "data-tauri-drag-region",
+      "AppSettings",
+      "UpdateReminder",
+      "PRODUCT_NAME",
+    ],
+  },
+  {
+    name: "FileViewer toolbar",
+    file: "components/FileViewer.tsx",
+    markers: ["FileViewerToolbar", "FileViewerStatus", "getFileIcon", "file-viewer-toolbar"],
+  },
+  {
+    name: "TabBar chrome",
+    file: "components/TabBar.tsx",
+    markers: ["file-tab-bar", "file-tab-label", "file-tab-close"],
+  },
+  {
+    name: "native theme layer",
+    file: "app/layout.tsx",
+    // Dropping this import silently reverts the entire restyle to upstream.
+    markers: ["./native-theme.css", "PRODUCT_NAME"],
+  },
+];
+
+for (const extraction of EXTRACTIONS) {
+  test(`${extraction.name}: extracted code does not reappear at its origin`, async () => {
+    const origin = await read(extraction.origin);
+
+    for (const symbol of extraction.movedDefinitions) {
+      assert.equal(
+        definesSymbol(origin, symbol),
+        false,
+        `${extraction.origin} defines ${symbol} again — an upstream merge probably resurrected it. ` +
+          `It belongs in ${extraction.movedTo.join(" or ")}; importing it is fine, redefining it is not.`,
+      );
+    }
+
+    for (const marker of extraction.absentFromOrigin) {
+      assert.ok(
+        !origin.includes(marker),
+        `${extraction.origin} contains "${marker}" again — project-picker logic moved to ` +
+          `${extraction.movedTo[0]} and must not come back.`,
+      );
+    }
+  });
+
+  test(`${extraction.name}: the extraction targets still own the moved code`, async () => {
+    const targets = await Promise.all(extraction.movedTo.map(read));
+
+    for (const symbol of extraction.movedDefinitions) {
+      assert.ok(
+        targets.some((source) => definesSymbol(source, symbol)),
+        `None of ${extraction.movedTo.join(", ")} defines ${symbol}.`,
+      );
+    }
+  });
+
+  test(`${extraction.name}: the origin still consumes the extraction`, async () => {
+    const origin = await read(extraction.origin);
+
+    for (const symbol of extraction.requiredInOrigin) {
+      assert.ok(
+        origin.includes(symbol),
+        `${extraction.origin} no longer references ${symbol} — the merge may have reverted it ` +
+          `to the upstream inline implementation.`,
+      );
+    }
+  });
+}
+
+for (const feature of FORK_FEATURES) {
+  test(`${feature.name}: fork changes survive upstream merges`, async () => {
+    const source = await read(feature.file);
+
+    for (const marker of feature.markers) {
+      assert.ok(
+        source.includes(marker),
+        `${feature.file} lost "${marker}" — an upstream merge likely reverted this file toward ` +
+          `its upstream form. Re-apply the fork change rather than deleting this assertion.`,
+      );
+    }
+  });
+}

--- a/components/fork-extractions.test.mjs
+++ b/components/fork-extractions.test.mjs
@@ -57,17 +57,36 @@ const EXTRACTIONS = [
     ],
     requiredInOrigin: ["ProjectPicker"],
   },
+  {
+    name: "AppShell window chrome",
+    origin: "components/AppShell.tsx",
+    // Desktop-only UI belongs in components/desktop/, so upstream layout files
+    // carry a mount point rather than Tauri calls and window state.
+    movedTo: ["components/desktop/WindowControls.tsx", "components/desktop/useDesktopChrome.ts"],
+    movedDefinitions: [],
+    absentFromOrigin: [
+      "minimizeWindow",
+      "toggleMaximizeWindow",
+      "closeWindow",
+      "isWindowMaximized",
+      "window-control-btn",
+      "@/lib/desktop-window",
+    ],
+    requiredInOrigin: ["WindowControls", "useDesktopChrome"],
+  },
 ];
 
 const FORK_FEATURES = [
   {
     name: "AppShell desktop chrome",
     file: "components/AppShell.tsx",
+    // The window buttons and platform detection live in components/desktop/ now;
+    // what AppShell must keep is the mount point and the drag-region spread.
     markers: [
-      "isTauriDesktop",
-      "getDesktopPlatform",
-      "toggleMaximizeWindow",
-      "data-tauri-drag-region",
+      "useDesktopChrome",
+      "WindowControls",
+      "dragRegionProps",
+      "app-topbar--mac-inset",
       "AppSettings",
       "UpdateReminder",
       "PRODUCT_NAME",
@@ -120,6 +139,16 @@ for (const extraction of EXTRACTIONS) {
       assert.ok(
         targets.some((source) => definesSymbol(source, symbol)),
         `None of ${extraction.movedTo.join(", ")} defines ${symbol}.`,
+      );
+    }
+
+    // Without this the origin-side check could pass simply because the code was
+    // deleted everywhere rather than relocated.
+    for (const marker of extraction.absentFromOrigin) {
+      assert.ok(
+        targets.some((source) => source.includes(marker)),
+        `"${marker}" is absent from ${extraction.origin} but also from ` +
+          `${extraction.movedTo.join(", ")} — it looks deleted, not moved.`,
       );
     }
   });

--- a/docs/ownership-boundaries.md
+++ b/docs/ownership-boundaries.md
@@ -62,12 +62,20 @@ is highly concentrated — four files carry 86% of it:
 | File | structural | why |
 |---|---|---|
 | `components/SessionSidebar.tsx` | 430 | ~500 lines moved out to `ProjectPicker.tsx` / `path-ui.tsx` |
-| `components/AppShell.tsx` | 429 | title bar, window controls, top-bar restructure |
+| `components/AppShell.tsx` | 376 | top-bar redesign (was 429 before the desktop chrome moved out) |
 | `components/FileViewer.tsx` | 305 | new toolbar/status components, inline SVG |
 | `components/TabBar.tsx` | 66 | tab chrome rebuilt |
 
-Every other shared component is already in acceptable shape. Reverting work should target
-these four and nothing else — `TabBar.tsx` first, since it is the smallest.
+Every other shared component is already in acceptable shape.
+
+Note what the `AppShell.tsx` number says. Moving the desktop chrome into
+`components/desktop/` removed only 53 of its 429 structural lines: the rest is the
+fork's own top-bar design — the toolbar consolidated into a more-menu, upstream's
+inline-styled buttons rebuilt — and it applies to the web build too. **That drift is the
+product, not a defect.** It cannot be cleaned up without deleting the differentiated
+interaction design, so `AppShell.tsx` stays a permanent review point rather than
+something to fix. The same will be true of any file where the fork's design genuinely
+diverges from upstream's.
 
 ## The failure mode this guards against
 
@@ -122,9 +130,11 @@ In order of preference:
    structural divergence disappears entirely. This is the only real fix, and it is the
    right home for things like the `ProjectPicker` extraction, the `FileViewer` toolbar,
    and `hooks/useTheme.ts` following `prefers-color-scheme`.
-3. **Genuinely desktop-only?** Put it in a fork-owned file and reach it from the
-   upstream file with a single import plus one `isTauriDesktop()` branch. Never restructure
-   upstream JSX to accommodate it.
+3. **Genuinely desktop-only?** Put it in `components/desktop/` and reach it from the
+   upstream file with a single import and a mount point. Components there render to
+   nothing in a browser build, so the host does not even need an `isTauriDesktop()`
+   branch around them — `<WindowControls />` is the reference. Never restructure
+   upstream JSX to accommodate desktop code.
 
 What to avoid: rewriting upstream JSX for visual reasons, and moving upstream code
 across file boundaries.

--- a/docs/ownership-boundaries.md
+++ b/docs/ownership-boundaries.md
@@ -1,0 +1,179 @@
+# Ownership boundaries
+
+This repository is a fork of [`agegr/pi-web`](https://github.com/agegr/pi-web) that
+packages it, together with the [`earendil-works/pi`](https://github.com/earendil-works/pi)
+SDK, into a signed desktop app. Three layers, three integration mechanisms:
+
+| Layer | Source | How it arrives | Who owns the files |
+|---|---|---|---|
+| Agent runtime | `@earendil-works/pi-*` | npm dependency, exact version | upstream |
+| Web UI | `agegr/pi-web` | `git merge` of an upstream release tag | upstream |
+| Desktop shell | this repo | authored here | fork |
+
+The whole maintenance cost of this project is concentrated in one place: **files the
+fork edits that upstream also owns.** Everything in this document exists to keep that
+set small and visible.
+
+## The machine-readable boundary
+
+[`scripts/fork-ownership.json`](../scripts/fork-ownership.json) is the single source of
+truth. It is consumed by:
+
+- `.github/workflows/component-updates.yml` — decides whether a nightly sync may push
+  to `main` unattended or must open a PR for review.
+- `scripts/fork-ownership.test.mjs` — fails if the manifest drifts from the tree.
+
+Update the manifest in the same commit that changes the boundary. Do not maintain a
+second copy of this list anywhere.
+
+## Cosmetic drift vs structural drift
+
+Not all divergence costs the same, and line count is a bad proxy for risk.
+
+pi-web styles its components with inline `style={{ … }}` objects, which a stylesheet
+cannot override. So restyling a shared component *necessarily* edits the upstream file:
+you delete the inline style and add a `className`. That produces a large diff — and it
+is fine. If upstream later edits the same line, git reports a textual conflict, the sync
+job fails, and a human looks at it. Loud failure is the safe failure.
+
+What is dangerous is **structural** drift: rewritten JSX trees, new components spliced
+into upstream files, and logic moved across file boundaries. Those merge *cleanly* while
+being wrong.
+
+`npm run drift` measures the split and flags any file whose recorded risk no longer
+matches:
+
+```
+components/ModelsConfig.tsx     146 total    134 cosmetic     12 structural   low
+components/AppShell.tsx         558 total    129 cosmetic    429 structural   high
+```
+
+Both files have big diffs. Only one of them is a problem. `ModelsConfig.tsx` is the
+reference for how a restyled shared component should look.
+
+Risk thresholds live in the manifest's `riskModel` and are applied to structural drift
+only: `>= 250` high, `>= 30` medium, below that low.
+
+### Where the structural drift actually is
+
+Across the whole fork: **973 cosmetic lines, 1462 structural**. But the structural half
+is highly concentrated — four files carry 86% of it:
+
+| File | structural | why |
+|---|---|---|
+| `components/SessionSidebar.tsx` | 430 | ~500 lines moved out to `ProjectPicker.tsx` / `path-ui.tsx` |
+| `components/AppShell.tsx` | 429 | title bar, window controls, top-bar restructure |
+| `components/FileViewer.tsx` | 305 | new toolbar/status components, inline SVG |
+| `components/TabBar.tsx` | 66 | tab chrome rebuilt |
+
+Every other shared component is already in acceptable shape. Reverting work should target
+these four and nothing else — `TabBar.tsx` first, since it is the smallest.
+
+## The failure mode this guards against
+
+`git merge` conflicts are the *safe* outcome — the sync workflow runs under
+`set -euo pipefail`, so a conflict fails the job and nothing ships.
+
+The dangerous outcome is a **silent semantic conflict**: upstream edits a region the
+fork also changed, git merges it cleanly because the edits do not textually overlap,
+and the result is two implementations of the same behaviour. Tests, `tsc --noEmit`
+and `eslint` all pass, and the previous pipeline pushed that straight to `main` and
+cut a signed release with no human in the loop.
+
+The worst instance today is `components/SessionSidebar.tsx`: roughly 500 lines were
+moved out into `components/ProjectPicker.tsx` and `components/path-ui.tsx`, neither of
+which exists upstream. Git does not track cross-file moves, so an upstream change to
+the project-picker block merges back into `SessionSidebar.tsx` cleanly and resurrects
+a second copy of code that now lives in `ProjectPicker.tsx`.
+
+Concrete measurement: upstream's `v0.8.0 → v0.8.1` patch release touched **7 files
+that this fork has also modified**, including all three of the highest-risk ones.
+Expect roughly a third of the files in any upstream release to land on fork-modified
+files until the structural drift is reverted.
+
+## Rules for changing a shared file
+
+In order of preference:
+
+1. **Style only?** Put the CSS in `app/native-theme.css` and, in the upstream component,
+   replace the inline `style={{ … }}` with a `className` — nothing else. Deleting the
+   inline style is unavoidable (a stylesheet cannot override it) and is not a boundary
+   violation; leaving the JSX shape untouched is the part that matters.
+   `app/globals.css` stays byte-identical to upstream — never edit it.
+   `native-theme.css` is imported after it in `app/layout.tsx` so equal-specificity
+   rules win.
+2. **Generally useful?** Send it upstream to `agegr/pi-web` as a PR. Once merged, the
+   structural divergence disappears entirely. This is the only real fix, and it is the
+   right home for things like the `ProjectPicker` extraction, the `FileViewer` toolbar,
+   and `hooks/useTheme.ts` following `prefers-color-scheme`.
+3. **Genuinely desktop-only?** Put it in a fork-owned file and reach it from the
+   upstream file with a single import plus one `isTauriDesktop()` branch. Never restructure
+   upstream JSX to accommodate it.
+
+What to avoid: rewriting upstream JSX for visual reasons, and moving upstream code
+across file boundaries.
+
+## Fork-owned files
+
+Safe to edit freely; upstream never touches them. Full list in the manifest's
+`forkOwnedPaths`. Broadly: `src-tauri/`, `desktop/`, `scripts/`, `.github/workflows/`,
+`app/native-theme.css`, `app/api/updates/`, `lib/branding.ts`, `lib/app-updates.ts`,
+`lib/desktop-updater.ts`, `lib/desktop-window.ts`, and the desktop-only components
+(`ProjectPicker`, `UpdateReminder`, `AppSettings`, `path-ui`).
+
+## Deliberate decisions that look like mistakes
+
+- **`package.json` is still named `@agegr/pi-web`.** This is intentional. Upstream
+  edits its own name and version on every release; renaming the fork would produce a
+  conflict in `package.json` on every single sync. The user-facing brand comes from
+  `lib/branding.ts` and `src-tauri/tauri.conf.json` instead. (JSON has no comments,
+  which is why this note lives here.)
+- **`next.config.ts` keeps its hand-written `serverExternalPackages` list.** It is
+  tempting to derive it from `package.json`, but this file is upstream-owned and
+  upstream updates that list itself when it adds a pi package. Auto-deriving it here
+  would manufacture a conflict on every release. The fork-owned copies of that list are
+  derived instead — `scripts/pi-packages.mjs` reads `package.json` and feeds both
+  `scripts/prepare-desktop.mjs` and the sync workflow, so adding a pi package cannot
+  leave one of them behind.
+- **`AGENTS.md` is an upstream file.** It does not mention Tauri and should not. Put
+  desktop maintenance notes in `docs/` and, at most, leave a one-line pointer there.
+- **Local builds do not register the updater.** `src-tauri` reads the public key via
+  `option_env!`, so a build without `PI_AGENT_DESKTOP_UPDATER_PUBLIC_KEY` simply has no
+  updater. Keep it that way — it prevents a local debug build from accepting update
+  payloads.
+
+## What the nightly sync does
+
+`.github/workflows/component-updates.yml`, at 02:17 daily:
+
+1. Resolves the latest `pi` and `pi-web` releases; stops if neither moved.
+2. Skips if a review PR for this upstream tag is already open.
+3. **Classifies the incoming upstream changeset against the manifest, before merging** —
+   after the merge commit exists, the incoming changeset can no longer be recovered
+   with a plain diff.
+4. Merges the upstream tag and updates the pi dependencies.
+5. Gates on `npm test` (including `components/*.test.mjs`), `tsc --noEmit`, `npm run lint`,
+   and a real standalone Next build.
+6. **No overlap** → pushes to `main` and dispatches the signed release.
+   **Overlap at blocked risk** → pushes `sync/pi-web-<tag>` and opens a PR with the
+   boundary report. Merging that PR is what triggers the release.
+7. On failure, files or comments on a `component-sync-failure` issue.
+
+A merge conflict fails step 4 and nothing ships — that is the design.
+
+## Reducing the cost
+
+The gate's `autoPushPolicy.blockOnRisk` currently blocks on `high` and `medium`, which
+means most upstream releases will require a reviewed PR. That is an accurate reflection
+of the current drift, not a pessimistic setting. It loosens on its own as structural
+drift is reverted to upstream and entries leave `driftedUpstreamFiles`.
+
+Narrow `blockOnRisk` only when the drift is actually gone — never to quiet the gate.
+
+## Commands
+
+```
+npm test        # the same gate CI runs: lib + scripts + components tests
+npm run drift   # cosmetic vs structural drift, flags stale manifest risk levels
+npm run lint    # eslint + branding check
+```

--- a/docs/ownership-boundaries.md
+++ b/docs/ownership-boundaries.md
@@ -56,17 +56,20 @@ only: `>= 250` high, `>= 30` medium, below that low.
 
 ### Where the structural drift actually is
 
-Across the whole fork: **973 cosmetic lines, 1462 structural**. But the structural half
-is highly concentrated — four files carry 86% of it:
+Across the whole fork: **969 cosmetic lines, 1379 structural**. But the structural half
+is highly concentrated — three files carry 80% of it:
 
-| File | structural | why |
+| File | structural | what it is |
 |---|---|---|
-| `components/SessionSidebar.tsx` | 430 | ~500 lines moved out to `ProjectPicker.tsx` / `path-ui.tsx` |
+| `components/SessionSidebar.tsx` | 430 | sidebar redesign; ~500 lines moved out to `ProjectPicker.tsx` / `path-ui.tsx` |
 | `components/AppShell.tsx` | 376 | top-bar redesign (was 429 before the desktop chrome moved out) |
-| `components/FileViewer.tsx` | 305 | new toolbar/status components, inline SVG |
-| `components/TabBar.tsx` | 66 | tab chrome rebuilt |
+| `components/FileViewer.tsx` | 305 | toolbar, status states, file icons, live-sync indicator |
+| `components/TabBar.tsx` | 66 | accessibility: tab roles, roving focus, arrow-key navigation |
+| `components/FileExplorer.tsx` | 61 | selection highlighting; git status colours on CSS variables |
+| `hooks/useTheme.ts` | 57 | follows the OS colour scheme until the user chooses |
+| `components/ChatWindow.tsx` | 35 | branding copy, minimap mount, empty state |
 
-Every other shared component is already in acceptable shape.
+Every other shared component is cosmetic-only.
 
 Note what the `AppShell.tsx` number says. Moving the desktop chrome into
 `components/desktop/` removed only 53 of its 429 structural lines: the rest is the
@@ -97,7 +100,7 @@ a second copy of code that now lives in `ProjectPicker.tsx`.
 Concrete measurement: upstream's `v0.8.0 → v0.8.1` patch release touched **7 files
 that this fork has also modified**, including all three of the highest-risk ones.
 Expect roughly a third of the files in any upstream release to land on fork-modified
-files until the structural drift is reverted.
+files. That rate is stable, not temporary — see the dispositions below.
 
 ### Sentinels
 
@@ -187,14 +190,46 @@ Safe to edit freely; upstream never touches them. Full list in the manifest's
 
 A merge conflict fails step 4 and nothing ships — that is the design.
 
-## Reducing the cost
+## What is settled, and what is not
 
-The gate's `autoPushPolicy.blockOnRisk` currently blocks on `high` and `medium`, which
-means most upstream releases will require a reviewed PR. That is an accurate reflection
-of the current drift, not a pessimistic setting. It loosens on its own as structural
-drift is reverted to upstream and entries leave `driftedUpstreamFiles`.
+Every entry in the manifest carries a `disposition`, and the reasoning is in
+`decisionLog`. Two values:
 
-Narrow `blockOnRisk` only when the drift is actually gone — never to quiet the gate.
+- **`reduce`** — drift that can go away without losing anything: desktop-only code that
+  belongs in `components/desktop/`, or fork additions sitting in an upstream file that
+  can move to a fork-owned one. Act on these.
+- **`accepted`** — reviewed and kept.
+
+As of 2026-07-26 everything remaining is `accepted`. Two rounds of `reduce` work are
+done: the desktop window chrome left `AppShell.tsx`, and the update types left
+`lib/api-types.ts` (which is now byte-identical to upstream and off the list entirely).
+
+What is left splits in two, and neither half is a backlog item:
+
+- **The fork's interaction design** — `AppShell.tsx` (376), `SessionSidebar.tsx` (430),
+  `ChatWindow.tsx` (35). This is the product. It cannot be cleaned up without deleting it.
+- **Generic improvements with zero desktop coupling** — `FileViewer.tsx` (305),
+  `TabBar.tsx` (66), `FileExplorer.tsx` (61), `hooks/useTheme.ts` (57). Accessibility,
+  selection highlighting, OS theme following, a file toolbar. None of it touches Tauri,
+  so `components/desktop/` is not a home for it; the only ways out are upstreaming it or
+  deleting a working feature. Upstreaming was declined, so these are kept.
+
+The consequence is that most upstream releases will open a review PR rather than
+publishing unattended. That is the running cost of maintaining a UI fork, priced
+honestly. The guardrails make it a review, not a silent failure — which was the goal.
+
+Narrow `blockOnRisk` only if the drift itself goes away. Never to quiet the gate.
+
+## When you add new drift
+
+Adding to a shared file is fine — just make the decision explicit:
+
+1. Run `npm run drift`. If the structural number moved, update the manifest.
+2. Give the entry a `disposition`. `reduce` means you intend to remove it; if you cannot
+   say how, it is `accepted` and you are choosing to pay for it.
+3. If you moved code out of a shared file, add a sentinel in
+   `components/fork-extractions.test.mjs` — that is the failure mode nothing else catches.
+4. Append a dated line to `decisionLog` so the next person does not re-litigate it.
 
 ## Commands
 

--- a/docs/ownership-boundaries.md
+++ b/docs/ownership-boundaries.md
@@ -91,6 +91,22 @@ that this fork has also modified**, including all three of the highest-risk ones
 Expect roughly a third of the files in any upstream release to land on fork-modified
 files until the structural drift is reverted.
 
+### Sentinels
+
+`components/fork-extractions.test.mjs` turns that silent failure into a loud one. It
+covers both directions a clean-but-wrong merge can go:
+
+- **Resurrection** — code the fork moved elsewhere reappears at its origin, e.g.
+  `displayCwd` getting redefined inside `SessionSidebar.tsx` while `path-ui.tsx` also
+  exports it. Importing a moved symbol is fine; redefining it is the signal.
+- **Erosion** — a fork change is dropped and the file quietly reverts toward upstream,
+  e.g. `AppShell.tsx` losing `data-tauri-drag-region`, or `app/layout.tsx` losing its
+  `native-theme.css` import (which would revert the entire restyle).
+
+The assertions are validated by mutation: each failure mode was injected and confirmed
+to fail the test. When one fires after a merge, re-apply the fork change — do not delete
+the assertion. Add a new entry whenever code is moved out of, or added to, a shared file.
+
 ## Rules for changing a shared file
 
 In order of preference:

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -89,38 +89,3 @@ export interface PluginsResponse {
   totals: PluginResourceCounts;
   diagnostics: PluginDiagnostic[];
 }
-
-export type AppUpdateProjectId = "pi-agent-desktop" | "pi" | "pi-web";
-
-export type AppReleaseStatus = "available" | "unpublished" | "unknown";
-
-export interface AppComponentReleaseInfo {
-  project: AppUpdateProjectId;
-  name: string;
-  repository: string;
-  repositoryUrl: string;
-  currentVersion: string;
-  latestVersion: string | null;
-  releaseUrl: string | null;
-  updateAvailable: boolean;
-  releaseStatus: AppReleaseStatus;
-}
-
-export interface AppUpdateInfo {
-  project: AppUpdateProjectId;
-  name: string;
-  currentVersion: string;
-  latestVersion: string;
-  releaseUrl: string;
-}
-
-export interface AppUpdatesResponse {
-  checkedAt: string;
-  nextCheckAt: string;
-  components: AppComponentReleaseInfo[];
-  updates: AppUpdateInfo[];
-  errors?: Array<{
-    project: AppUpdateProjectId;
-    message: string;
-  }>;
-}

--- a/lib/app-update-types.ts
+++ b/lib/app-update-types.ts
@@ -1,0 +1,43 @@
+/**
+ * Types for the desktop update check.
+ *
+ * Kept out of lib/api-types.ts, which agegr/pi-web owns and extends on its own
+ * schedule. Appending fork types there made every upstream edit to that file
+ * land on a fork-modified file for no benefit — nothing outside the desktop
+ * update flow consumes these. See docs/ownership-boundaries.md.
+ */
+
+export type AppUpdateProjectId = "pi-agent-desktop" | "pi" | "pi-web";
+
+export type AppReleaseStatus = "available" | "unpublished" | "unknown";
+
+export interface AppComponentReleaseInfo {
+  project: AppUpdateProjectId;
+  name: string;
+  repository: string;
+  repositoryUrl: string;
+  currentVersion: string;
+  latestVersion: string | null;
+  releaseUrl: string | null;
+  updateAvailable: boolean;
+  releaseStatus: AppReleaseStatus;
+}
+
+export interface AppUpdateInfo {
+  project: AppUpdateProjectId;
+  name: string;
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+}
+
+export interface AppUpdatesResponse {
+  checkedAt: string;
+  nextCheckAt: string;
+  components: AppComponentReleaseInfo[];
+  updates: AppUpdateInfo[];
+  errors?: Array<{
+    project: AppUpdateProjectId;
+    message: string;
+  }>;
+}

--- a/lib/app-updates.ts
+++ b/lib/app-updates.ts
@@ -4,7 +4,7 @@ import type {
   AppComponentReleaseInfo,
   AppUpdateInfo,
   AppUpdateProjectId,
-} from "@/lib/api-types";
+} from "@/lib/app-update-types";
 import { APP_DISTRIBUTION_NAME, APP_VERSION } from "./branding";
 
 export const APP_UPDATE_CHECK_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release:verify": "node scripts/verify-release-components.mjs",
     "drift": "node scripts/measure-fork-drift.mjs",
     "test:release-tools": "node --test scripts/*.test.mjs",
-    "test": "node --test lib/*.test.mjs scripts/*.test.mjs components/*.test.mjs",
+    "test": "node --test 'lib/**/*.test.mjs' 'scripts/**/*.test.mjs' 'components/**/*.test.mjs'",
     "lint": "eslint . && npm run check:branding",
     "check:branding": "node --test lib/branding.test.mjs",
     "release": "npm version patch --no-git-tag-version && npm run build && npm publish --access public"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "desktop:build": "npm run desktop:prepare && tauri build",
     "release:manifest": "node scripts/write-component-versions.mjs",
     "release:verify": "node scripts/verify-release-components.mjs",
+    "drift": "node scripts/measure-fork-drift.mjs",
     "test:release-tools": "node --test scripts/*.test.mjs",
+    "test": "node --test lib/*.test.mjs scripts/*.test.mjs components/*.test.mjs",
     "lint": "eslint . && npm run check:branding",
     "check:branding": "node --test lib/branding.test.mjs",
     "release": "npm version patch --no-git-tag-version && npm run build && npm publish --access public"

--- a/scripts/fork-ownership.json
+++ b/scripts/fork-ownership.json
@@ -95,12 +95,6 @@
       "reason": "Already the correct shape: 3 structural lines out of 44, the rest is style-to-className substitution. Nothing to revert.",
       "structuralDrift": 3
     },
-    "lib/api-types.ts": {
-      "risk": "medium",
-      "drift": 30,
-      "reason": "Fork-added update-check types share a file with upstream API types.",
-      "structuralDrift": 30
-    },
     "next.config.ts": {
       "risk": "medium",
       "drift": 21,
@@ -182,6 +176,7 @@
     "components/fork-extractions.test.mjs",
     "lib/branding.ts",
     "lib/branding.test.mjs",
+    "lib/app-update-types.ts",
     "lib/app-updates.ts",
     "lib/app-updates.test.mjs",
     "lib/desktop-updater.ts",

--- a/scripts/fork-ownership.json
+++ b/scripts/fork-ownership.json
@@ -178,6 +178,7 @@
     "components/UpdateReminder.tsx",
     "components/AppSettings.tsx",
     "components/path-ui.tsx",
+    "components/fork-extractions.test.mjs",
     "lib/branding.ts",
     "lib/branding.test.mjs",
     "lib/app-updates.ts",

--- a/scripts/fork-ownership.json
+++ b/scripts/fork-ownership.json
@@ -20,145 +20,169 @@
       "high",
       "medium"
     ],
-    "note": "Risk levels that force the sync to open a reviewed PR instead of pushing straight to main and triggering a signed release. As P1 reverts structural drift back to upstream, entries drop out of driftedUpstreamFiles and more releases qualify for unattended sync. Narrow this list only when the drift is actually gone — not to silence the gate."
+    "note": "Risk levels that force the sync to open a reviewed PR instead of pushing straight to main and triggering a signed release. Most upstream releases will land here, because the remaining drift is accepted by decision rather than pending cleanup — see `dispositions` and `decisionLog`. Narrow this list only if the drift itself actually goes away."
   },
   "driftedUpstreamFiles": {
     "components/SessionSidebar.tsx": {
       "risk": "high",
       "drift": 601,
       "reason": "~500 lines were MOVED OUT into components/ProjectPicker.tsx and components/path-ui.tsx, which do not exist upstream. git merge does not track cross-file moves: an upstream edit to the project-picker block can merge back cleanly and silently resurrect a second copy.",
-      "structuralDrift": 430
+      "structuralDrift": 430,
+      "disposition": "accepted"
     },
     "components/AppShell.tsx": {
       "risk": "high",
       "drift": 501,
       "reason": "Top-bar redesign (toolbar consolidated into a more-menu, inline styles to classNames) plus the mount point for desktop chrome. The desktop-only parts moved to components/desktop/; the remaining 376 structural lines are the fork's own interaction design, not desktop plumbing, so this file stays high risk by design rather than by neglect.",
-      "structuralDrift": 376
+      "structuralDrift": 376,
+      "disposition": "accepted"
     },
     "components/FileViewer.tsx": {
       "risk": "high",
       "drift": 456,
-      "reason": "Adds FileViewerToolbar / FileViewerStatus components and inline SVG iconography. Structural JSX rewrite, not a restyle.",
-      "structuralDrift": 305
+      "reason": "Adds FileViewerToolbar and FileViewerStatus, file icons, a live-sync indicator and a retry action. Both components are defined inside FileViewer.tsx rather than moved out, so there is no cross-file resurrection risk — only a large diff. Kept deliberately.",
+      "structuralDrift": 305,
+      "disposition": "accepted"
     },
     "components/FileExplorer.tsx": {
       "risk": "medium",
       "drift": 168,
-      "reason": "Tree row structure and icon rendering reworked.",
-      "structuralDrift": 61
+      "reason": "Adds selection highlighting (selectedPath/onSelectPath) and moves git status colours onto CSS variables. Generic improvement, no desktop coupling. Kept deliberately.",
+      "structuralDrift": 61,
+      "disposition": "accepted"
     },
     "components/ModelsConfig.tsx": {
       "risk": "low",
       "drift": 146,
       "reason": "Already the correct shape: upstream inline style objects swapped for native-* classNames, 12 structural lines out of 146. Conflicts here are textual and trivially resolvable. Use this file as the model for restyling a shared component.",
-      "structuralDrift": 12
+      "structuralDrift": 12,
+      "disposition": "accepted"
     },
     "components/TabBar.tsx": {
       "risk": "medium",
       "drift": 112,
-      "reason": "Tab chrome rebuilt rather than restyled: 66 of 112 changed lines are structural. The smallest of the four genuine P1 revert targets, so a good place to start.",
-      "structuralDrift": 66
+      "reason": "Accessibility work: role=\"tab\", aria-selected, roving tabIndex, arrow-key navigation, Enter/Space activation, plus an empty state. A generic improvement with no desktop coupling, so it cannot be extracted anywhere — the only ways to remove this drift are upstreaming it or deleting the accessibility support. Kept deliberately.",
+      "structuralDrift": 66,
+      "disposition": "accepted"
     },
     "components/ChatWindow.tsx": {
       "risk": "medium",
       "drift": 89,
-      "reason": "Header and empty-state markup adjusted.",
-      "structuralDrift": 35
+      "reason": "Branding copy, the ChatMinimap mount and a redesigned empty state. Part of the fork's interaction design. Kept deliberately.",
+      "structuralDrift": 35,
+      "disposition": "accepted"
     },
     "hooks/useTheme.ts": {
       "risk": "medium",
       "drift": 57,
-      "reason": "Adds prefers-color-scheme following. Good upstream-PR candidate.",
-      "structuralDrift": 57
+      "reason": "Follows the OS colour scheme until the user picks a theme explicitly, and drops the ToggleOrigin argument so the view transition always starts from the centre. The view transition itself is unchanged from upstream. Kept deliberately.",
+      "structuralDrift": 57,
+      "disposition": "accepted"
     },
     "components/PluginsConfig.tsx": {
       "risk": "low",
       "drift": 50,
       "reason": "Already the correct shape: 2 structural lines out of 50, the rest is style-to-className substitution. Nothing to revert.",
-      "structuralDrift": 2
+      "structuralDrift": 2,
+      "disposition": "accepted"
     },
     "components/ChatInput.tsx": {
       "risk": "low",
       "drift": 49,
       "reason": "Composer chrome restyle. Upstream changed this file in v0.8.1, and components/ChatInput.test.mjs covers it.",
-      "structuralDrift": 7
+      "structuralDrift": 7,
+      "disposition": "accepted"
     },
     "components/MessageView.tsx": {
       "risk": "low",
       "drift": 46,
       "reason": "Message bubble markup adjusted.",
-      "structuralDrift": 5
+      "structuralDrift": 5,
+      "disposition": "accepted"
     },
     "components/SkillsConfig.tsx": {
       "risk": "low",
       "drift": 44,
       "reason": "Already the correct shape: 3 structural lines out of 44, the rest is style-to-className substitution. Nothing to revert.",
-      "structuralDrift": 3
+      "structuralDrift": 3,
+      "disposition": "accepted"
     },
     "next.config.ts": {
       "risk": "medium",
       "drift": 21,
-      "reason": "Desktop standalone build branch. Also holds serverExternalPackages, which upstream updates whenever it adds a pi package — do NOT auto-derive that list here."
+      "reason": "Desktop standalone build branch. Also holds serverExternalPackages, which upstream updates whenever it adds a pi package — do NOT auto-derive that list here.",
+      "disposition": "accepted"
     },
     "app/layout.tsx": {
       "risk": "low",
       "drift": 10,
       "reason": "native-theme.css import, branding title, dark-mode bootstrap script.",
-      "structuralDrift": 10
+      "structuralDrift": 10,
+      "disposition": "accepted"
     },
     "components/ChatMinimap.tsx": {
       "risk": "low",
       "drift": 8,
       "reason": "className hooks only, no structural change — the intended shape for every restyled file.",
-      "structuralDrift": 2
+      "structuralDrift": 2,
+      "disposition": "accepted"
     },
     "eslint.config.mjs": {
       "risk": "low",
       "drift": 7,
-      "reason": "Adds ignores for the desktop build output directories."
+      "reason": "Adds ignores for the desktop build output directories.",
+      "disposition": "accepted"
     },
     "lib/rpc-manager.ts": {
       "risk": "low",
       "drift": 5,
       "reason": "Small fork edit in a file upstream changes often; watch it despite the low drift count.",
-      "structuralDrift": 5
+      "structuralDrift": 5,
+      "disposition": "accepted"
     },
     "components/FileIcons.tsx": {
       "risk": "low",
       "drift": 5,
       "reason": "Adds an icon size parameter, consumed by the fork's FileViewer toolbar.",
-      "structuralDrift": 3
+      "structuralDrift": 3,
+      "disposition": "accepted"
     },
     "components/BranchNavigator.tsx": {
       "risk": "low",
       "drift": 1,
       "reason": "className hook only, no structural change — the intended shape for every restyled file.",
-      "structuralDrift": 0
+      "structuralDrift": 0,
+      "disposition": "accepted"
     },
     "package.json": {
       "risk": "low",
       "drift": 13,
-      "reason": "Desktop scripts and Tauri deps. Name stays @agegr/pi-web on purpose — see docs/ownership-boundaries.md."
+      "reason": "Desktop scripts and Tauri deps. Name stays @agegr/pi-web on purpose — see docs/ownership-boundaries.md.",
+      "disposition": "accepted"
     },
     "tsconfig.json": {
       "risk": "low",
       "drift": 4,
-      "reason": "resolveJsonModule for branding."
+      "reason": "resolveJsonModule for branding.",
+      "disposition": "accepted"
     },
     ".gitignore": {
       "risk": "low",
       "drift": 7,
-      "reason": "Desktop build output plus local agent tooling state (.claude/, .spec-workflow/)."
+      "reason": "Desktop build output plus local agent tooling state (.claude/, .spec-workflow/).",
+      "disposition": "accepted"
     },
     "README.md": {
       "risk": "low",
       "drift": 266,
-      "reason": "Fork-specific product docs. Conflicts here are noisy but harmless — resolve by keeping the fork version."
+      "reason": "Fork-specific product docs. Conflicts here are noisy but harmless — resolve by keeping the fork version.",
+      "disposition": "accepted"
     },
     "README.zh-CN.md": {
       "risk": "low",
       "drift": 200,
-      "reason": "Fork-specific product docs. Same handling as README.md."
+      "reason": "Fork-specific product docs. Same handling as README.md.",
+      "disposition": "accepted"
     }
   },
   "forkOwnedPaths": [
@@ -182,5 +206,14 @@
     "lib/desktop-updater.ts",
     "lib/desktop-window.ts",
     "docs/ownership-boundaries.md"
+  ],
+  "dispositions": {
+    "accepted": "Reviewed and kept. The drift is either the fork's own interaction design or a generic improvement with no desktop coupling, so it cannot be extracted into components/desktop/. Removing it would mean deleting a feature. These files stay permanent review points; that is the running cost of a UI fork, not a backlog item. Do not reopen without new information.",
+    "reduce": "Drift that can be removed without losing anything — desktop-only code that belongs in components/desktop/, or fork additions sitting in an upstream file that can move to a fork-owned one. Act on these."
+  },
+  "decisionLog": [
+    "2026-07-26 — lib/api-types.ts: fork update types moved to lib/app-update-types.ts; file now matches upstream and left the manifest.",
+    "2026-07-26 — components/AppShell.tsx: desktop window chrome moved to components/desktop/ (-53 structural). The remaining 376 lines are the top-bar redesign; accepted.",
+    "2026-07-26 — TabBar, FileExplorer, useTheme, FileViewer: assessed as generic improvements with zero desktop coupling. Upstreaming was declined, so accepted rather than reverted — reverting would delete working features to save CI review time."
   ]
 }

--- a/scripts/fork-ownership.json
+++ b/scripts/fork-ownership.json
@@ -1,0 +1,189 @@
+{
+  "schemaVersion": 1,
+  "upstreamBaseline": "v0.8.1",
+  "note": "Single source of truth for the pi-web merge boundary. `driftedUpstreamFiles` lists files agegr/pi-web owns that this fork has also edited — every one is a potential merge conflict, and a potential SILENT semantic conflict when git merges cleanly but the two sides changed different things. The automated sync (.github/workflows/component-updates.yml) intersects each incoming upstream release with this map to decide whether it may push to main unattended. Human-facing rationale lives in docs/ownership-boundaries.md.",
+  "ignored": [
+    "package-lock.json",
+    "bun.lock",
+    "src-tauri/Cargo.lock"
+  ],
+  "riskModel": {
+    "basis": "structuralDrift",
+    "thresholds": {
+      "high": 250,
+      "medium": 30
+    },
+    "note": "Risk follows STRUCTURAL drift, not total drift. Replacing an upstream inline style object with a className produces a large diff, but an upstream edit to the same line conflicts textually and fails the sync loudly — that is safe. Rewritten JSX trees and code moved across files are what merge cleanly while being wrong. components/ModelsConfig.tsx is the reference: 146 changed lines, only 12 structural, correctly rated low. Recompute with the hunk classifier described in docs/ownership-boundaries.md after any significant change to a shared file."
+  },
+  "autoPushPolicy": {
+    "blockOnRisk": [
+      "high",
+      "medium"
+    ],
+    "note": "Risk levels that force the sync to open a reviewed PR instead of pushing straight to main and triggering a signed release. As P1 reverts structural drift back to upstream, entries drop out of driftedUpstreamFiles and more releases qualify for unattended sync. Narrow this list only when the drift is actually gone — not to silence the gate."
+  },
+  "driftedUpstreamFiles": {
+    "components/SessionSidebar.tsx": {
+      "risk": "high",
+      "drift": 601,
+      "reason": "~500 lines were MOVED OUT into components/ProjectPicker.tsx and components/path-ui.tsx, which do not exist upstream. git merge does not track cross-file moves: an upstream edit to the project-picker block can merge back cleanly and silently resurrect a second copy.",
+      "structuralDrift": 430
+    },
+    "components/AppShell.tsx": {
+      "risk": "high",
+      "drift": 558,
+      "reason": "Custom title bar, drag regions, platform window controls, top-bar restructure, AppSettings/UpdateReminder mounting. Mixes desktop-conditional logic with unconditional layout changes.",
+      "structuralDrift": 429
+    },
+    "components/FileViewer.tsx": {
+      "risk": "high",
+      "drift": 456,
+      "reason": "Adds FileViewerToolbar / FileViewerStatus components and inline SVG iconography. Structural JSX rewrite, not a restyle.",
+      "structuralDrift": 305
+    },
+    "components/FileExplorer.tsx": {
+      "risk": "medium",
+      "drift": 168,
+      "reason": "Tree row structure and icon rendering reworked.",
+      "structuralDrift": 61
+    },
+    "components/ModelsConfig.tsx": {
+      "risk": "low",
+      "drift": 146,
+      "reason": "Already the correct shape: upstream inline style objects swapped for native-* classNames, 12 structural lines out of 146. Conflicts here are textual and trivially resolvable. Use this file as the model for restyling a shared component.",
+      "structuralDrift": 12
+    },
+    "components/TabBar.tsx": {
+      "risk": "medium",
+      "drift": 112,
+      "reason": "Tab chrome rebuilt rather than restyled: 66 of 112 changed lines are structural. The smallest of the four genuine P1 revert targets, so a good place to start.",
+      "structuralDrift": 66
+    },
+    "components/ChatWindow.tsx": {
+      "risk": "medium",
+      "drift": 89,
+      "reason": "Header and empty-state markup adjusted.",
+      "structuralDrift": 35
+    },
+    "hooks/useTheme.ts": {
+      "risk": "medium",
+      "drift": 57,
+      "reason": "Adds prefers-color-scheme following. Good upstream-PR candidate.",
+      "structuralDrift": 57
+    },
+    "components/PluginsConfig.tsx": {
+      "risk": "low",
+      "drift": 50,
+      "reason": "Already the correct shape: 2 structural lines out of 50, the rest is style-to-className substitution. Nothing to revert.",
+      "structuralDrift": 2
+    },
+    "components/ChatInput.tsx": {
+      "risk": "low",
+      "drift": 49,
+      "reason": "Composer chrome restyle. Upstream changed this file in v0.8.1, and components/ChatInput.test.mjs covers it.",
+      "structuralDrift": 7
+    },
+    "components/MessageView.tsx": {
+      "risk": "low",
+      "drift": 46,
+      "reason": "Message bubble markup adjusted.",
+      "structuralDrift": 5
+    },
+    "components/SkillsConfig.tsx": {
+      "risk": "low",
+      "drift": 44,
+      "reason": "Already the correct shape: 3 structural lines out of 44, the rest is style-to-className substitution. Nothing to revert.",
+      "structuralDrift": 3
+    },
+    "lib/api-types.ts": {
+      "risk": "medium",
+      "drift": 30,
+      "reason": "Fork-added update-check types share a file with upstream API types.",
+      "structuralDrift": 30
+    },
+    "next.config.ts": {
+      "risk": "medium",
+      "drift": 21,
+      "reason": "Desktop standalone build branch. Also holds serverExternalPackages, which upstream updates whenever it adds a pi package — do NOT auto-derive that list here."
+    },
+    "app/layout.tsx": {
+      "risk": "low",
+      "drift": 10,
+      "reason": "native-theme.css import, branding title, dark-mode bootstrap script.",
+      "structuralDrift": 10
+    },
+    "components/ChatMinimap.tsx": {
+      "risk": "low",
+      "drift": 8,
+      "reason": "className hooks only, no structural change — the intended shape for every restyled file.",
+      "structuralDrift": 2
+    },
+    "eslint.config.mjs": {
+      "risk": "low",
+      "drift": 7,
+      "reason": "Adds ignores for the desktop build output directories."
+    },
+    "lib/rpc-manager.ts": {
+      "risk": "low",
+      "drift": 5,
+      "reason": "Small fork edit in a file upstream changes often; watch it despite the low drift count.",
+      "structuralDrift": 5
+    },
+    "components/FileIcons.tsx": {
+      "risk": "low",
+      "drift": 5,
+      "reason": "Adds an icon size parameter, consumed by the fork's FileViewer toolbar.",
+      "structuralDrift": 3
+    },
+    "components/BranchNavigator.tsx": {
+      "risk": "low",
+      "drift": 1,
+      "reason": "className hook only, no structural change — the intended shape for every restyled file.",
+      "structuralDrift": 0
+    },
+    "package.json": {
+      "risk": "low",
+      "drift": 13,
+      "reason": "Desktop scripts and Tauri deps. Name stays @agegr/pi-web on purpose — see docs/ownership-boundaries.md."
+    },
+    "tsconfig.json": {
+      "risk": "low",
+      "drift": 4,
+      "reason": "resolveJsonModule for branding."
+    },
+    ".gitignore": {
+      "risk": "low",
+      "drift": 7,
+      "reason": "Desktop build output plus local agent tooling state (.claude/, .spec-workflow/)."
+    },
+    "README.md": {
+      "risk": "low",
+      "drift": 266,
+      "reason": "Fork-specific product docs. Conflicts here are noisy but harmless — resolve by keeping the fork version."
+    },
+    "README.zh-CN.md": {
+      "risk": "low",
+      "drift": 200,
+      "reason": "Fork-specific product docs. Same handling as README.md."
+    }
+  },
+  "forkOwnedPaths": [
+    "src-tauri/",
+    "desktop/",
+    "scripts/",
+    ".github/workflows/",
+    "app/native-theme.css",
+    "app/api/updates/",
+    "components/ProjectPicker.tsx",
+    "components/UpdateReminder.tsx",
+    "components/AppSettings.tsx",
+    "components/path-ui.tsx",
+    "lib/branding.ts",
+    "lib/branding.test.mjs",
+    "lib/app-updates.ts",
+    "lib/app-updates.test.mjs",
+    "lib/desktop-updater.ts",
+    "lib/desktop-window.ts",
+    "docs/ownership-boundaries.md"
+  ]
+}

--- a/scripts/fork-ownership.json
+++ b/scripts/fork-ownership.json
@@ -31,9 +31,9 @@
     },
     "components/AppShell.tsx": {
       "risk": "high",
-      "drift": 558,
-      "reason": "Custom title bar, drag regions, platform window controls, top-bar restructure, AppSettings/UpdateReminder mounting. Mixes desktop-conditional logic with unconditional layout changes.",
-      "structuralDrift": 429
+      "drift": 501,
+      "reason": "Top-bar redesign (toolbar consolidated into a more-menu, inline styles to classNames) plus the mount point for desktop chrome. The desktop-only parts moved to components/desktop/; the remaining 376 structural lines are the fork's own interaction design, not desktop plumbing, so this file stays high risk by design rather than by neglect.",
+      "structuralDrift": 376
     },
     "components/FileViewer.tsx": {
       "risk": "high",
@@ -174,6 +174,7 @@
     ".github/workflows/",
     "app/native-theme.css",
     "app/api/updates/",
+    "components/desktop/",
     "components/ProjectPicker.tsx",
     "components/UpdateReminder.tsx",
     "components/AppSettings.tsx",

--- a/scripts/fork-ownership.mjs
+++ b/scripts/fork-ownership.mjs
@@ -1,0 +1,136 @@
+/**
+ * Merge-boundary classifier for pi-web upstream syncs.
+ *
+ * Reads scripts/fork-ownership.json and answers one question: does this
+ * incoming upstream release touch files this fork has also edited? If it does,
+ * `git merge` may succeed while the two sides silently disagree, so the sync
+ * must stop for a human instead of pushing to main and cutting a signed
+ * release unattended.
+ *
+ * CLI:
+ *   node scripts/fork-ownership.mjs classify <paths-file>
+ *   git diff --name-only BASE TAG | node scripts/fork-ownership.mjs classify -
+ */
+
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifestPath = join(rootDir, "scripts", "fork-ownership.json");
+
+export const RISK_ORDER = ["low", "medium", "high"];
+
+export async function readForkOwnership() {
+  return JSON.parse(await readFile(manifestPath, "utf8"));
+}
+
+/**
+ * Intersect an incoming upstream changeset with the fork's drifted files.
+ *
+ * @param {string[]} changedFiles paths upstream changed since our last sync
+ * @param {object} manifest result of readForkOwnership()
+ */
+export function classifyIncomingChanges(changedFiles, manifest) {
+  const ignored = new Set(manifest.ignored ?? []);
+  const drifted = manifest.driftedUpstreamFiles ?? {};
+  const blockOn = new Set(manifest.autoPushPolicy?.blockOnRisk ?? ["high", "medium"]);
+
+  const overlaps = [];
+  for (const file of changedFiles) {
+    const path = file.trim();
+    if (!path || ignored.has(path)) continue;
+    const entry = drifted[path];
+    if (entry) overlaps.push({ path, ...entry });
+  }
+
+  // Rank by structural drift, not total drift: swapping an inline style object
+  // for a className produces a big diff that conflicts textually (and so fails
+  // loudly), while a rewritten JSX tree produces the silent kind.
+  const weight = (entry) => entry.structuralDrift ?? entry.drift ?? 0;
+  overlaps.sort((a, b) => {
+    const byRisk = RISK_ORDER.indexOf(b.risk) - RISK_ORDER.indexOf(a.risk);
+    return byRisk !== 0 ? byRisk : weight(b) - weight(a);
+  });
+
+  const highestRisk = overlaps.reduce(
+    (worst, entry) =>
+      RISK_ORDER.indexOf(entry.risk) > RISK_ORDER.indexOf(worst) ? entry.risk : worst,
+    "none",
+  );
+
+  return {
+    overlaps,
+    highestRisk,
+    reviewRequired: overlaps.some((entry) => blockOn.has(entry.risk)),
+  };
+}
+
+/** Human-readable report for CI logs and PR bodies. */
+export function formatReport(result) {
+  if (result.overlaps.length === 0) {
+    return "No overlap with fork-modified upstream files. Safe for unattended sync.";
+  }
+
+  const lines = [
+    `This upstream release touches ${result.overlaps.length} file(s) the fork has also modified.`,
+    "Review each one for silent semantic conflicts — a clean `git merge` does not mean the two sides agree.",
+    "",
+  ];
+  for (const entry of result.overlaps) {
+    const drift =
+      entry.structuralDrift === undefined
+        ? `${entry.drift} lines`
+        : `${entry.structuralDrift} structural of ${entry.drift} lines`;
+    lines.push(`- **${entry.path}** (risk: ${entry.risk}, fork drift: ${drift})`);
+    lines.push(`  ${entry.reason}`);
+  }
+  lines.push("", "Boundary rules: docs/ownership-boundaries.md");
+  return lines.join("\n");
+}
+
+async function readPaths(source) {
+  if (source === "-" || source === undefined) {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    return Buffer.concat(chunks).toString("utf8");
+  }
+  return readFile(source, "utf8");
+}
+
+async function main() {
+  const [command, source] = process.argv.slice(2);
+  if (command !== "classify") {
+    console.error("usage: node scripts/fork-ownership.mjs classify <paths-file|->");
+    process.exitCode = 2;
+    return;
+  }
+
+  const manifest = await readForkOwnership();
+  const changedFiles = (await readPaths(source)).split("\n").filter(Boolean);
+  const result = classifyIncomingChanges(changedFiles, manifest);
+  const report = formatReport(result);
+
+  console.log(report);
+
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFile } = await import("node:fs/promises");
+    // The report is multi-line, so it needs heredoc-delimited output syntax.
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      [
+        `review_required=${result.reviewRequired}`,
+        `highest_risk=${result.highestRisk}`,
+        `overlap_count=${result.overlaps.length}`,
+        "report<<FORK_OWNERSHIP_EOF",
+        report,
+        "FORK_OWNERSHIP_EOF",
+        "",
+      ].join("\n"),
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/fork-ownership.test.mjs
+++ b/scripts/fork-ownership.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  RISK_ORDER,
+  classifyIncomingChanges,
+  formatReport,
+  readForkOwnership,
+} from "./fork-ownership.mjs";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifest = await readForkOwnership();
+
+async function exists(relativePath) {
+  try {
+    await access(join(rootDir, relativePath), constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("every drifted file entry is well formed", () => {
+  const entries = Object.entries(manifest.driftedUpstreamFiles);
+  assert.ok(entries.length > 0);
+
+  for (const [path, entry] of entries) {
+    assert.ok(RISK_ORDER.includes(entry.risk), `${path}: unknown risk "${entry.risk}"`);
+    assert.equal(typeof entry.drift, "number", `${path}: drift must be a number`);
+    assert.ok(entry.reason?.length > 20, `${path}: reason must explain the conflict mode`);
+  }
+});
+
+test("drifted files still exist — stale entries would silently weaken the gate", async () => {
+  for (const path of Object.keys(manifest.driftedUpstreamFiles)) {
+    assert.ok(await exists(path), `${path} is listed as drifted but is missing from the tree`);
+  }
+});
+
+test("fork-owned paths still exist", async () => {
+  for (const path of manifest.forkOwnedPaths) {
+    assert.ok(await exists(path), `${path} is listed as fork-owned but is missing from the tree`);
+  }
+});
+
+test("the structurally rewritten files are all classified high risk", () => {
+  // These carry rewritten JSX or code moved across files, where a clean merge
+  // is the dangerous outcome rather than the safe one.
+  for (const path of [
+    "components/SessionSidebar.tsx",
+    "components/AppShell.tsx",
+    "components/FileViewer.tsx",
+  ]) {
+    assert.equal(manifest.driftedUpstreamFiles[path]?.risk, "high", `${path} must stay high risk`);
+  }
+});
+
+test("risk follows the declared structural-drift thresholds", () => {
+  // Guards against someone downgrading a file's risk without actually
+  // reverting the structural drift that earned it.
+  const { high, medium } = manifest.riskModel.thresholds;
+  for (const [path, entry] of Object.entries(manifest.driftedUpstreamFiles)) {
+    if (entry.structuralDrift === undefined) continue;
+    const expected =
+      entry.structuralDrift >= high ? "high" : entry.structuralDrift >= medium ? "medium" : "low";
+    assert.equal(
+      entry.risk,
+      expected,
+      `${path}: ${entry.structuralDrift} structural lines should be ${expected}, not ${entry.risk}`,
+    );
+  }
+});
+
+test("style-only drift is rated low even when the diff is large", () => {
+  // ModelsConfig changes 146 lines but only 13 structurally, because the rest
+  // is inline-style-to-className substitution. That must not block a sync.
+  const entry = manifest.driftedUpstreamFiles["components/ModelsConfig.tsx"];
+  assert.ok(entry.drift > 100, "expected a large total diff");
+  assert.ok(entry.structuralDrift < 30, "expected small structural drift");
+  assert.equal(entry.risk, "low");
+});
+
+test("high and medium overlaps require review; low-only does not", () => {
+  const high = classifyIncomingChanges(["components/SessionSidebar.tsx"], manifest);
+  assert.equal(high.reviewRequired, true);
+  assert.equal(high.highestRisk, "high");
+
+  const medium = classifyIncomingChanges(["components/ChatWindow.tsx"], manifest);
+  assert.equal(medium.reviewRequired, true);
+  assert.equal(medium.highestRisk, "medium");
+
+  const low = classifyIncomingChanges(
+    ["components/BranchNavigator.tsx", "components/ModelsConfig.tsx"],
+    manifest,
+  );
+  assert.equal(low.reviewRequired, false);
+  assert.equal(low.highestRisk, "low");
+});
+
+test("untouched and ignored files never trigger review", () => {
+  const result = classifyIncomingChanges(
+    ["app/api/skills/route.ts", "lib/directory-browser.ts", "package-lock.json", ""],
+    manifest,
+  );
+  assert.equal(result.reviewRequired, false);
+  assert.equal(result.highestRisk, "none");
+  assert.equal(result.overlaps.length, 0);
+  assert.match(formatReport(result), /Safe for unattended sync/);
+});
+
+test("the real v0.8.0 -> v0.8.1 changeset would have demanded review", () => {
+  // Regression anchor: this is what upstream actually shipped in one patch
+  // release. Seven of these files carry fork drift, so the previous
+  // push-straight-to-signed-release path was applying them unattended.
+  const result = classifyIncomingChanges(
+    [
+      "app/api/models/route.ts",
+      "app/globals.css",
+      "bin/pi-web.js",
+      "components/AppShell.tsx",
+      "components/ChatInput.tsx",
+      "components/ChatWindow.tsx",
+      "components/DirectoryPicker.tsx",
+      "components/FileViewer.tsx",
+      "components/MessageView.tsx",
+      "components/SessionSidebar.tsx",
+      "hooks/useAgentSession.ts",
+      "lib/directory-browser.ts",
+      "lib/rpc-manager.ts",
+    ],
+    manifest,
+  );
+
+  assert.equal(result.reviewRequired, true);
+  assert.equal(result.highestRisk, "high");
+  assert.equal(result.overlaps.length, 7);
+  assert.equal(result.overlaps[0].risk, "high", "the riskiest overlap must be reported first");
+  assert.match(formatReport(result), /silent semantic conflicts/);
+});

--- a/scripts/fork-ownership.test.mjs
+++ b/scripts/fork-ownership.test.mjs
@@ -35,6 +35,30 @@ test("every drifted file entry is well formed", () => {
   }
 });
 
+test("every drifted file has a recorded disposition", () => {
+  // New drift should force a decision — keep it and accept the review cost, or
+  // remove it — rather than accumulating silently on the blocked list.
+  const known = Object.keys(manifest.dispositions);
+  assert.ok(known.length > 0, "the manifest must define its disposition vocabulary");
+
+  for (const [path, entry] of Object.entries(manifest.driftedUpstreamFiles)) {
+    assert.ok(
+      known.includes(entry.disposition),
+      `${path}: disposition must be one of ${known.join(", ")}, got ${entry.disposition}`,
+    );
+  }
+});
+
+test("the decision log is not empty", () => {
+  // Records why the accepted files were accepted, so the call is not re-litigated
+  // from scratch by whoever next reads a blocked sync PR.
+  assert.ok(Array.isArray(manifest.decisionLog));
+  assert.ok(manifest.decisionLog.length >= 3);
+  for (const entry of manifest.decisionLog) {
+    assert.match(entry, /^\d{4}-\d{2}-\d{2} — /, `decision log entries need a date: ${entry}`);
+  }
+});
+
 test("drifted files still exist — stale entries would silently weaken the gate", async () => {
   for (const path of Object.keys(manifest.driftedUpstreamFiles)) {
     assert.ok(await exists(path), `${path} is listed as drifted but is missing from the tree`);

--- a/scripts/measure-fork-drift.mjs
+++ b/scripts/measure-fork-drift.mjs
@@ -70,14 +70,16 @@ function baselineFromManifest() {
 const manifest = await readForkOwnership();
 const baseline = resolveBaseline(process.argv[2]);
 
-const files = git("diff", "--name-status", baseline, "HEAD")
+// Diffed against the working tree, not HEAD, so the effect of an in-progress
+// revert is visible before it is committed.
+const files = git("diff", "--name-status", baseline)
   .split("\n")
   .filter((line) => line.startsWith("M\t"))
   .map((line) => line.split("\t")[1])
   .filter((file) => /^(?:components|hooks|lib|app)\/.*\.tsx?$/.test(file));
 
 const rows = files.map((file) => {
-  const diff = git("diff", "-U0", baseline, "HEAD", "--", file);
+  const diff = git("diff", "-U0", baseline, "--", file);
   let cosmetic = 0;
   let structural = 0;
 

--- a/scripts/measure-fork-drift.mjs
+++ b/scripts/measure-fork-drift.mjs
@@ -1,0 +1,137 @@
+/**
+ * Measure how far this fork has drifted from the pi-web baseline, split by the
+ * distinction that actually matters for merge safety:
+ *
+ *   cosmetic   — inline style objects swapped for classNames, colour tokens.
+ *                Produces big diffs, but an upstream edit to the same line
+ *                conflicts textually and fails the sync loudly. Safe.
+ *   structural — rewritten JSX, new components, logic moved across files.
+ *                Merges cleanly while being wrong. This is the real risk.
+ *
+ * Feeds the `risk` and `structuralDrift` fields in scripts/fork-ownership.json.
+ * Re-run it after any significant change to a shared file:
+ *
+ *   node scripts/measure-fork-drift.mjs [baseline-ref]
+ *
+ * The baseline defaults to the merge base with the last synced upstream tag.
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readForkOwnership } from "./fork-ownership.mjs";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const git = (...args) => execFileSync("git", args, { cwd: rootDir, encoding: "utf8" });
+
+// CSS-ish property names that appear in inline style objects.
+const STYLE_PROPS = [
+  "display", "flex", "flexDirection", "flexShrink", "gap", "padding", "margin",
+  "font", "fontSize", "fontWeight", "fontFamily", "color", "background",
+  "backgroundColor", "border", "borderRadius", "width", "height", "minWidth",
+  "maxWidth", "minHeight", "maxHeight", "alignItems", "alignSelf", "justifyContent",
+  "cursor", "opacity", "position", "top", "left", "right", "bottom", "overflow",
+  "overflowX", "overflowY", "transition", "transform", "boxShadow", "lineHeight",
+  "letterSpacing", "textAlign", "whiteSpace", "zIndex", "accentColor", "objectFit",
+  "pointerEvents", "userSelect", "textOverflow", "borderColor", "borderBottom",
+  "borderTop", "borderLeft", "borderRight", "outline", "visibility", "content",
+].join("|");
+
+// Each entry is a top-level alternative — keep the `|` joins explicit, since a
+// bare concatenation silently turns the alternation into a sequence.
+const COSMETIC = new RegExp(
+  [
+    "className=",
+    "style=\\{",
+    `^\\s*(?:${STYLE_PROPS})\\s*:`,
+    "^\\s*[\"']?#[0-9a-fA-F]{3,8}",
+    "var\\(--",
+  ].join("|"),
+);
+
+function resolveBaseline(explicit) {
+  if (explicit) return explicit;
+  try {
+    return git("merge-base", "HEAD", "pi-web-upstream/main").trim();
+  } catch {
+    const manifest = baselineFromManifest();
+    console.error(`No pi-web-upstream remote; falling back to tag ${manifest}.`);
+    return manifest;
+  }
+}
+
+let cachedManifest;
+function baselineFromManifest() {
+  cachedManifest ??= manifest;
+  return cachedManifest.upstreamBaseline;
+}
+
+const manifest = await readForkOwnership();
+const baseline = resolveBaseline(process.argv[2]);
+
+const files = git("diff", "--name-status", baseline, "HEAD")
+  .split("\n")
+  .filter((line) => line.startsWith("M\t"))
+  .map((line) => line.split("\t")[1])
+  .filter((file) => /^(?:components|hooks|lib|app)\/.*\.tsx?$/.test(file));
+
+const rows = files.map((file) => {
+  const diff = git("diff", "-U0", baseline, "HEAD", "--", file);
+  let cosmetic = 0;
+  let structural = 0;
+
+  for (const line of diff.split("\n")) {
+    if (!/^[+-]/.test(line) || /^(?:\+\+\+|---)/.test(line)) continue;
+    const body = line.slice(1);
+    if (!body.trim()) continue;
+    if (COSMETIC.test(body)) cosmetic += 1;
+    else structural += 1;
+  }
+
+  return { file, cosmetic, structural, total: cosmetic + structural };
+});
+
+rows.sort((a, b) => b.structural - a.structural);
+
+const { high, medium } = manifest.riskModel.thresholds;
+const riskFor = (structural) =>
+  structural >= high ? "high" : structural >= medium ? "medium" : "low";
+
+console.log(`baseline: ${baseline}\n`);
+console.log(
+  "file".padEnd(34),
+  "total".padStart(6),
+  "cosmetic".padStart(9),
+  "structural".padStart(11),
+  "  risk",
+);
+
+let drifted = 0;
+for (const row of rows) {
+  const risk = riskFor(row.structural);
+  const recorded = manifest.driftedUpstreamFiles[row.file];
+  const stale = recorded && recorded.risk !== risk ? `  <- manifest says ${recorded.risk}` : "";
+  if (stale) drifted += 1;
+  console.log(
+    row.file.padEnd(34),
+    String(row.total).padStart(6),
+    String(row.cosmetic).padStart(9),
+    String(row.structural).padStart(11),
+    `  ${risk}${stale}`,
+  );
+}
+
+const totals = rows.reduce(
+  (acc, row) => ({ c: acc.c + row.cosmetic, s: acc.s + row.structural }),
+  { c: 0, s: 0 },
+);
+const structuralShare = Math.round((totals.s / (totals.c + totals.s)) * 100);
+console.log(
+  `\ncosmetic: ${totals.c}   structural: ${totals.s}   (${structuralShare}% structural)`,
+);
+
+if (drifted > 0) {
+  console.error(`\n${drifted} file(s) disagree with scripts/fork-ownership.json — update it.`);
+  process.exitCode = 1;
+}

--- a/scripts/pi-packages.mjs
+++ b/scripts/pi-packages.mjs
@@ -1,0 +1,64 @@
+/**
+ * The set of `@earendil-works/*` packages this app bundles, derived from
+ * package.json so it cannot drift when a pi package is added or removed.
+ *
+ * Deliberately NOT used for `serverExternalPackages` in next.config.ts: that
+ * file is owned by agegr/pi-web upstream, which maintains its own copy of the
+ * list. Deriving it here would manufacture a merge conflict on every sync.
+ * See docs/ownership-boundaries.md.
+ *
+ * CLI:
+ *   node scripts/pi-packages.mjs --install-spec 0.82.1  # npm install arguments
+ *   node scripts/pi-packages.mjs --names                # bare package names
+ */
+
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCOPE = "@earendil-works/";
+
+/** Fully scoped package names, e.g. `@earendil-works/pi-ai`. */
+export async function piPackageNames() {
+  const pkg = JSON.parse(await readFile(join(rootDir, "package.json"), "utf8"));
+  const names = Object.keys(pkg.dependencies ?? {})
+    .filter((name) => name.startsWith(SCOPE))
+    .sort();
+
+  if (names.length === 0) {
+    throw new Error("No @earendil-works/* dependencies found in package.json.");
+  }
+  return names;
+}
+
+/** Unscoped names, matching the directory layout under node_modules/@earendil-works. */
+export async function piPackageDirNames() {
+  return (await piPackageNames()).map((name) => name.slice(SCOPE.length));
+}
+
+async function main() {
+  const [flag, version] = process.argv.slice(2);
+
+  if (flag === "--names") {
+    console.log((await piPackageNames()).join("\n"));
+    return;
+  }
+
+  if (flag === "--install-spec") {
+    if (!version) {
+      console.error("--install-spec requires a version argument");
+      process.exitCode = 2;
+      return;
+    }
+    console.log((await piPackageNames()).map((name) => `${name}@${version}`).join(" "));
+    return;
+  }
+
+  console.error("usage: node scripts/pi-packages.mjs --install-spec <version> | --names");
+  process.exitCode = 2;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/prepare-desktop.mjs
+++ b/scripts/prepare-desktop.mjs
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { desktopTargetTriple } from "./desktop-platform.mjs";
+import { piPackageDirNames } from "./pi-packages.mjs";
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const desktopBuildDir = join(rootDir, ".next-desktop");
@@ -12,12 +13,6 @@ const standaloneDir = join(desktopBuildDir, "standalone");
 const serverResourcesDir = join(rootDir, "src-tauri", "resources", "server");
 const serverHelperDir = join(rootDir, "src-tauri", "resources", "Pi Agent Server.app");
 const windowsNodeDir = join(rootDir, "src-tauri", "resources", "node");
-const externalPackages = [
-  "pi-coding-agent",
-  "pi-agent-core",
-  "pi-ai",
-  "pi-tui",
-];
 
 async function runNextBuild() {
   const require = createRequire(import.meta.url);
@@ -53,7 +48,7 @@ async function assembleServer() {
   // Next's file tracer follows normal imports but intentionally omits files
   // reached through dynamic provider/export/plugin paths. These packages are
   // serverExternalPackages, so preserve their complete runtime `dist/` trees.
-  for (const packageName of externalPackages) {
+  for (const packageName of await piPackageDirNames()) {
     const source = join(rootDir, "node_modules", "@earendil-works", packageName, "dist");
     const destination = join(
       serverResourcesDir,

--- a/scripts/release-workflows.test.mjs
+++ b/scripts/release-workflows.test.mjs
@@ -6,20 +6,98 @@ import test from "node:test";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
-test("component updates use main directly and dispatch the release workflow", async () => {
-  const workflow = await readFile(
-    join(root, ".github", "workflows", "component-updates.yml"),
-    "utf8",
-  );
+const componentUpdates = await readFile(
+  join(root, ".github", "workflows", "component-updates.yml"),
+  "utf8",
+);
 
-  assert.match(workflow, /cron: "17 2 \* \* \*"/);
-  assert.match(workflow, /actions: write/);
-  assert.match(workflow, /contents: write/);
-  assert.match(workflow, /git push origin HEAD:main/);
-  assert.match(workflow, /gh workflow run release\.yml .*--ref main/);
-  assert.doesNotMatch(workflow, /codex\/component-updates/);
-  assert.doesNotMatch(workflow, /gh pr (?:create|edit)/);
-  assert.doesNotMatch(workflow, /--force/);
+test("component updates run daily with the permissions the sync needs", () => {
+  assert.match(componentUpdates, /cron: "17 2 \* \* \*"/);
+  assert.match(componentUpdates, /actions: write/);
+  assert.match(componentUpdates, /contents: write/);
+  assert.match(componentUpdates, /pull-requests: write/);
+  assert.match(componentUpdates, /issues: write/);
+  assert.doesNotMatch(componentUpdates, /codex\/component-updates/);
+});
+
+test("the boundary is classified before the merge, not after", () => {
+  // Once a merge commit exists the incoming changeset can no longer be
+  // recovered with a plain diff, so ordering here is load-bearing.
+  const classifyAt = componentUpdates.indexOf("fork-ownership.mjs classify");
+  const mergeAt = componentUpdates.indexOf("git merge --no-edit --no-ff");
+  assert.ok(classifyAt > -1, "sync must classify the upstream changeset");
+  assert.ok(mergeAt > -1, "sync must still merge the upstream tag");
+  assert.ok(classifyAt < mergeAt, "classification must run before the merge");
+});
+
+test("unattended publish is gated on the fork boundary", () => {
+  // A clean merge into a fork-modified file can be a silent semantic conflict,
+  // so only a no-overlap sync may reach a signed release without review.
+  assert.match(
+    componentUpdates,
+    /steps\.boundary\.outputs\.review_required != 'true'[\s\S]{0,400}git push origin HEAD:main/,
+  );
+  const reviewStep = componentUpdates.slice(componentUpdates.indexOf("Open a review PR"));
+  assert.match(reviewStep, /steps\.boundary\.outputs\.review_required == 'true'/);
+  assert.match(reviewStep, /gh pr create/);
+  assert.match(componentUpdates, /gh workflow run release\.yml .*--ref main/);
+});
+
+test("the release dispatch is unreachable from the review path", () => {
+  // The PR path must not also fire the signed build; review has to mean review.
+  const reviewStep = componentUpdates.slice(componentUpdates.indexOf("Open a review PR"));
+  assert.doesNotMatch(reviewStep, /gh workflow run release\.yml/);
+});
+
+test("the merge gate covers tests, types, lint and a real build", () => {
+  assert.match(componentUpdates, /npm test/);
+  assert.match(componentUpdates, /tsc --noEmit/);
+  assert.match(componentUpdates, /npm run lint/);
+  assert.match(componentUpdates, /PI_WEB_DESKTOP_BUILD=1 node_modules\/\.bin\/next build/);
+});
+
+test("npm test covers component tests, so the sync gate cannot skip them", async () => {
+  // Upstream ships components/*.test.mjs covering fork-modified files. The
+  // sync gate ran only lib/ and scripts/, silently skipping them every night.
+  const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  assert.match(pkg.scripts.test, /components\/\*\.test\.mjs/);
+  assert.match(pkg.scripts.test, /lib\/\*\.test\.mjs/);
+  assert.match(pkg.scripts.test, /scripts\/\*\.test\.mjs/);
+});
+
+test("a sync already awaiting review is skipped, not retried nightly", () => {
+  // needs_update stays true while a review PR is open, so without this guard
+  // the job would rebuild and collide with its own branch every night — and
+  // file a failure issue each time.
+  assert.match(componentUpdates, /gh pr list[\s\S]{0,160}--head "sync\/pi-web-\$PI_WEB_TAG"/);
+  assert.match(componentUpdates, /awaiting_review=true/);
+
+  const gated = componentUpdates
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("if: steps.releases.outputs.needs_update"));
+  assert.ok(gated.length >= 3, "expected the sync/verify/publish steps to be gated");
+  for (const line of gated) {
+    assert.match(line, /steps\.pending\.outputs\.awaiting_review != 'true'/);
+  }
+});
+
+test("a failed sync is reported instead of failing silently", () => {
+  assert.match(componentUpdates, /if: failure\(\)/);
+  assert.match(componentUpdates, /gh issue create/);
+  assert.match(componentUpdates, /component-sync-failure/);
+});
+
+test("the pi package list is derived, never hand-written in the workflow", () => {
+  assert.match(componentUpdates, /scripts\/pi-packages\.mjs --install-spec/);
+  assert.doesNotMatch(componentUpdates, /@earendil-works\/pi-coding-agent@/);
+  assert.doesNotMatch(componentUpdates, /@earendil-works\/pi-tui@/);
+});
+
+test("history is never rewritten on main", () => {
+  // --force-with-lease on the disposable sync branch is fine; a bare --force
+  // anywhere, or any force push to main, is not.
+  assert.doesNotMatch(componentUpdates, /--force(?!-with-lease)/);
+  assert.doesNotMatch(componentUpdates, /push .*--force-with-lease origin HEAD:main/);
 });
 
 test("release workflow publishes Apple Silicon and Windows x64 installers", async () => {

--- a/scripts/release-workflows.test.mjs
+++ b/scripts/release-workflows.test.mjs
@@ -56,13 +56,34 @@ test("the merge gate covers tests, types, lint and a real build", () => {
   assert.match(componentUpdates, /PI_WEB_DESKTOP_BUILD=1 node_modules\/\.bin\/next build/);
 });
 
-test("npm test covers component tests, so the sync gate cannot skip them", async () => {
-  // Upstream ships components/*.test.mjs covering fork-modified files. The
-  // sync gate ran only lib/ and scripts/, silently skipping them every night.
+test("npm test covers every test directory, recursively", async () => {
+  // Upstream ships components/*.test.mjs covering fork-modified files, and the
+  // sync gate once ran only lib/ and scripts/, silently skipping them nightly.
+  // The globs must recurse too: a flat components/*.test.mjs skips the
+  // fork-owned tests under components/desktop/.
   const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  assert.match(pkg.scripts.test, /components\/\*\.test\.mjs/);
-  assert.match(pkg.scripts.test, /lib\/\*\.test\.mjs/);
-  assert.match(pkg.scripts.test, /scripts\/\*\.test\.mjs/);
+  for (const dir of ["lib", "scripts", "components"]) {
+    assert.match(
+      pkg.scripts.test,
+      new RegExp(`${dir}/\\*\\*/\\*\\.test\\.mjs`),
+      `npm test must recurse into ${dir}/`,
+    );
+  }
+});
+
+test("no test file is left out of npm test", async () => {
+  // Catches a test added in a directory the globs do not cover.
+  const { execFileSync } = await import("node:child_process");
+  const tracked = execFileSync("git", ["ls-files", "*.test.mjs"], { cwd: root, encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean);
+
+  const covered = tracked.filter((file) => /^(lib|scripts|components)\//.test(file));
+  assert.deepEqual(
+    tracked.filter((file) => !covered.includes(file)),
+    [],
+    "a .test.mjs file lives outside lib/, scripts/ and components/ — extend npm test",
+  );
 });
 
 test("a sync already awaiting review is skipped, not retried nightly", () => {


### PR DESCRIPTION
## Why

The nightly sync merged an upstream `pi-web` release, ran a partial test suite, then pushed to `main` and dispatched a **signed release with no human in the loop**.

A merge conflict fails that job loudly, which is fine. The gap was the silent case: upstream edits a region this fork also rewrote, git merges it cleanly because the edits don't textually overlap, and two implementations of the same behaviour ship. `tsc`, `eslint` and the tests all pass.

That is not hypothetical. Upstream's `v0.8.0 → v0.8.1` patch release touched **7 files this fork has also modified**, including its three riskiest. And `components/SessionSidebar.tsx` had ~500 lines moved out into `ProjectPicker.tsx` / `path-ui.tsx` — git doesn't track cross-file moves, so an upstream edit to that region merges straight back and resurrects a second copy.

## What changed

**Boundary gate.** `scripts/fork-ownership.json` is the single source of truth for which upstream files this fork has modified. The sync classifies each incoming changeset against it **before merging** — once the merge commit exists, the incoming changeset can't be recovered with a plain diff. No overlap still pushes to `main` unattended; an overlap at blocked risk opens a review PR and does not release.

**Risk follows structural drift, not total drift.** pi-web styles with inline `style={{…}}` objects that a stylesheet can't override, so restyling a shared component necessarily edits the upstream file — and that's safe, because an upstream edit to the same line conflicts textually. Rewritten JSX and cross-file moves are what merge cleanly while being wrong. `npm run drift` measures the split:

| | total | cosmetic | structural | risk |
|---|---|---|---|---|
| `ModelsConfig.tsx` | 146 | 134 | 12 | low |
| `AppShell.tsx` | 501 | 125 | 376 | high |

Both have big diffs. Only one is a problem.

**Sentinels** (`components/fork-extractions.test.mjs`) cover both directions a clean-but-wrong merge can go — *resurrection* (moved code reappears at its origin) and *erosion* (a fork change is dropped and the file reverts upstream). Validated by mutation, not by passing.

**Three gaps closed alongside:**
- `components/*.test.mjs` was never in the sync gate — three upstream tests covering fork-modified files, silently skipped every night. The test set now lives in `package.json` and recurses; the gate also runs a real standalone build.
- A failed sync was silent. It now files or comments on a reusable issue, and a sync already awaiting review is skipped rather than rebuilt and re-failed nightly.
- The pi package list was hand-written in three fork-owned places, now derived from `package.json`. `next.config.ts` keeps its own copy deliberately — that file is upstream-owned.

**Drift actually reduced,** where it could be without losing anything:
- Desktop window chrome moved out of `AppShell.tsx` into `components/desktop/` (−53 structural). Components there render to nothing in a browser build, so the host mounts `<WindowControls />` with no `isTauriDesktop()` branch.
- Update types moved out of `lib/api-types.ts` into `lib/app-update-types.ts`. That file is now byte-identical to upstream and off the manifest entirely.

## What is deliberately *not* fixed

`AppShell` (376 structural), `SessionSidebar` (430) and `ChatWindow` (35) are the fork's interaction design. `FileViewer` (305), `TabBar` (66), `FileExplorer` (61) and `useTheme` (57) are generic improvements — accessibility, selection highlighting, OS theme following — with **zero desktop coupling**, so `components/desktop/` is not a home for them. The only routes out were upstreaming or deleting working features.

These are recorded as `disposition: accepted` with a dated `decisionLog`, and a test enforces that every drifted file has a disposition so new drift forces an explicit call.

**Consequence: most upstream releases will open a review PR rather than publishing unattended.** That is the running cost of a UI fork, priced honestly. The guardrails make it a review instead of a silent failure.

## Verification

199 tests, `tsc --noEmit`, lint, and a real standalone Next build all pass. `npm run desktop:prepare` verified end-to-end (all four pi packages bundled with complete `dist/` trees). Browser-verified: no console errors, top bar renders, no drag region or window controls in a web build, `/api/updates` returns all three components, settings panel renders them.

**Not yet verified:** the workflow's `gh pr create`, issue notification and boundary intersection paths only execute on a real upstream release. This branch doesn't touch `src-tauri/pi-agent-desktop-package.json`, so merging it does not trigger a release.

Boundary rules and rationale: `docs/ownership-boundaries.md`.
