### PR TITLE
Fix desktop reconnect after sleep

### DIFF
--- a/.github/workflows/component-updates.yml
+++ b/.github/workflows/component-updates.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pi-agent-desktop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out pi-agent-desktop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Require updater signing secrets
         shell: bash
@@ -45,7 +45,7 @@ jobs:
           test -n "$UPDATER_PUBLIC_KEY"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pi-agent-desktop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Upload component manifest to the release
         env:

--- a/.github/workflows/windows-build-debug.yml
+++ b/.github/workflows/windows-build-debug.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out pi-agent-desktop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/lib/desktop-connection.test.mjs
+++ b/lib/desktop-connection.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const connectionSource = new URL("./desktop-connection.ts", import.meta.url);
+const nativeSource = new URL("./desktop-native.ts", import.meta.url);
+
+test("desktop health probes ignore superseded wake-up requests", async () => {
+  const source = await readFile(connectionSource, "utf8");
+  assert.match(source, /probeControllerRef\.current\?\.abort\(\)/);
+  assert.match(source, /probeControllerRef\.current !== controller/);
+  assert.match(source, /probeControllerRef\.current === controller/);
+});
+
+test("Reconnect refreshes healthy connections and relaunches a dead local server", async () => {
+  const [connection, native] = await Promise.all([
+    readFile(connectionSource, "utf8"),
+    readFile(nativeSource, "utf8"),
+  ]);
+  assert.match(connection, /window\.location\.reload\(\)/);
+  assert.match(connection, /await relaunchAppNative\(\)/);
+  assert.match(native, /import\("@tauri-apps\/plugin-process"\)/);
+  assert.match(native, /await relaunch\(\)/);
+});

--- a/lib/desktop-connection.ts
+++ b/lib/desktop-connection.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { relaunchAppNative } from "@/lib/desktop-native";
+
 export type DesktopConnectionState = "online" | "offline" | "checking";
 
 const PING_INTERVAL_MS = 8_000;
@@ -18,11 +20,18 @@ export function useDesktopConnection(enabled = true): {
   const [state, setState] = useState<DesktopConnectionState>(enabled ? "checking" : "online");
   const failuresRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const probeControllerRef = useRef<AbortController | null>(null);
   const stoppedRef = useRef(false);
 
-  const probe = useCallback(async () => {
-    if (!enabled) return;
+  const probe = useCallback(async (): Promise<boolean | null> => {
+    if (!enabled || stoppedRef.current) return null;
+
+    // Wake/online/timer events can arrive together after sleep. Only the most
+    // recent probe may change connection state; otherwise a stale timeout can
+    // overwrite a newer successful response and leave the banner stuck.
+    probeControllerRef.current?.abort();
     const controller = new AbortController();
+    probeControllerRef.current = controller;
     const timeout = window.setTimeout(() => controller.abort(), 4_000);
     try {
       const res = await fetch(`/api/home?_=${Date.now()}`, {
@@ -31,19 +40,24 @@ export function useDesktopConnection(enabled = true): {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      if (stoppedRef.current) return;
+      if (stoppedRef.current || probeControllerRef.current !== controller) return null;
       failuresRef.current = 0;
       setState("online");
+      return true;
     } catch {
-      if (stoppedRef.current) return;
+      if (stoppedRef.current || probeControllerRef.current !== controller) return null;
       failuresRef.current += 1;
       if (failuresRef.current >= OFFLINE_THRESHOLD) {
         setState("offline");
       } else {
         setState((prev) => (prev === "offline" ? "offline" : "checking"));
       }
+      return false;
     } finally {
       window.clearTimeout(timeout);
+      if (probeControllerRef.current === controller) {
+        probeControllerRef.current = null;
+      }
     }
   }, [enabled]);
 
@@ -53,16 +67,44 @@ export function useDesktopConnection(enabled = true): {
     if (timerRef.current) clearTimeout(timerRef.current);
     if (!enabled || stoppedRef.current) return;
     timerRef.current = setTimeout(() => {
+      timerRef.current = null;
       void probe().finally(() => schedule());
     }, PING_INTERVAL_MS);
   }, [enabled, probe]);
 
   const retry = useCallback(() => {
     if (!enabled) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
     setState("checking");
     failuresRef.current = 0;
-    void probe();
-  }, [enabled, probe]);
+    void probe().then(async (reachable) => {
+      if (stoppedRef.current || reachable === null) return;
+      if (reachable) {
+        // Recreate every HTTP/SSE connection, not only the health probe.
+        window.location.reload();
+        return;
+      }
+
+      try {
+        // Tauri IPC remains available even when the localhost server is not.
+        // Relaunching recreates both the WebView and packaged Node server.
+        await relaunchAppNative();
+      } catch {
+        if (!stoppedRef.current) {
+          setState("offline");
+          schedule();
+        }
+      }
+    });
+  }, [enabled, probe, schedule]);
+
+  const checkNow = useCallback(() => {
+    if (!enabled) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+    void probe().finally(() => schedule());
+  }, [enabled, probe, schedule]);
 
   useEffect(() => {
     if (!enabled) {
@@ -70,23 +112,25 @@ export function useDesktopConnection(enabled = true): {
       return;
     }
     stoppedRef.current = false;
-    void probe().finally(() => schedule());
+    checkNow();
 
     const onVisible = () => {
-      if (document.visibilityState === "visible") retry();
+      if (document.visibilityState === "visible") checkNow();
     };
-    const onOnline = () => retry();
+    const onOnline = () => checkNow();
 
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("online", onOnline);
     return () => {
       stoppedRef.current = true;
+      probeControllerRef.current?.abort();
+      probeControllerRef.current = null;
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("online", onOnline);
     };
-  }, [enabled, probe, retry, schedule]);
+  }, [checkNow, enabled]);
 
   return { state: enabled ? state : "online", retry };
 }

--- a/lib/desktop-native.ts
+++ b/lib/desktop-native.ts
@@ -345,4 +345,11 @@ export async function showMainWindowNative(): Promise<void> {
   await invoke("show_main_window_cmd");
 }
 
+/** Relaunch the desktop shell and its packaged local server. */
+export async function relaunchAppNative(): Promise<void> {
+  if (!isTauriDesktop()) return;
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  await relaunch();
+}
+
 export { isTauriDesktop };


### PR DESCRIPTION
## What changed

- cancel superseded desktop health probes so stale wake-up timeouts cannot overwrite newer successes
- refresh the WebView when the local server is reachable to rebuild HTTP and SSE connections
- relaunch the desktop shell through Tauri IPC when the packaged local server is unreachable
- add regression coverage for wake-up probe ordering and reconnect fallback behavior

## Why

After the computer resumed from sleep, timer, visibility, and online events could start overlapping health probes. A stale failed probe could leave the offline banner visible even after the local server recovered. The existing Reconnect button only repeated the same HTTP request, so it could not repair stale WebView connections or restart a dead packaged server.

## Impact

Reconnect now recovers both cases: a healthy server with stale WebView connections and an unavailable packaged server. Periodic health checks continue without restarting the app automatically.

## Validation

- `node_modules/.bin/tsc --noEmit`
- targeted ESLint for changed files
- `npm test` — 398 passed