### PR TITLE
Fix desktop session reliability issues

### DIFF
--- a/app/api/agent/[id]/events/route.ts
+++ b/app/api/agent/[id]/events/route.ts
@@ -25,40 +25,57 @@ export async function GET(
     }
   }
 
+  let dispose = () => {};
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder();
-      const encode = (data: unknown) => {
-        const text = `data: ${JSON.stringify(data)}\n\n`;
-        controller.enqueue(encoder.encode(text));
+      let closed = false;
+      let unsubscribe = () => {};
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        if (heartbeat) clearInterval(heartbeat);
+        unsubscribe();
+        req.signal?.removeEventListener("abort", cleanup);
+        try { controller.close(); } catch { /* already closed/cancelled */ }
       };
+      const encode = (data: unknown) => {
+        if (closed) return false;
+        const text = `data: ${JSON.stringify(data)}\n\n`;
+        try {
+          controller.enqueue(encoder.encode(text));
+          return true;
+        } catch {
+          cleanup();
+          return false;
+        }
+      };
+      dispose = cleanup;
+      req.signal?.addEventListener("abort", cleanup);
 
       // Send initial connected event
       encode({ type: "connected", sessionId: id });
 
-      const unsubscribe = session.onEvent((event) => {
-        const clientEvent = projectAgentEventForClient(event);
-        if (clientEvent) encode(clientEvent);
-      });
+      if (!closed) {
+        const nextUnsubscribe = session.onEvent((event) => {
+          const clientEvent = projectAgentEventForClient(event);
+          if (clientEvent) encode(clientEvent);
+        });
+        if (closed) nextUnsubscribe();
+        else unsubscribe = nextUnsubscribe;
+      }
 
       // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s)
-      const heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(":\n\n"));
-        } catch {
-          // controller already closed
-        }
+      if (!closed) heartbeat = setInterval(() => {
+        if (closed) return;
+        try { controller.enqueue(encoder.encode(":\n\n")); }
+        catch { cleanup(); }
       }, 30_000);
 
-      // Cleanup when client disconnects
-      const cleanup = () => {
-        clearInterval(heartbeat);
-        unsubscribe();
-        controller.close();
-      };
-
-      // Detect client disconnect via abort signal
-      req.signal?.addEventListener("abort", cleanup);
+    },
+    cancel() {
+      dispose();
     },
   });
 

--- a/app/api/agent/events-route.test.mjs
+++ b/app/api/agent/events-route.test.mjs
@@ -20,3 +20,12 @@ test("SSE routes reuse one TextEncoder per stream", () => {
     assert.match(source, /controller\.enqueue\(encoder\.encode\(":\\n\\n"\)\)/);
   }
 });
+
+test("SSE routes clean up safely when the response consumer cancels", () => {
+  for (const source of [agentEventsSource, runningEventsSource]) {
+    assert.match(source, /let dispose = \(\) => \{\}/);
+    assert.match(source, /if \(closed\) return/);
+    assert.match(source, /try \{ controller\.close\(\); \} catch/);
+    assert.match(source, /cancel\(\) \{\s*dispose\(\);/);
+  }
+});

--- a/app/api/agent/running/events/route.ts
+++ b/app/api/agent/running/events/route.ts
@@ -6,44 +6,57 @@ export const dynamic = "force-dynamic";
 // session ids. Pushes an update whenever any session starts or stops working,
 // so the sidebar never has to poll.
 export async function GET(req: Request) {
+  let dispose = () => {};
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder();
+      let closed = false;
+      let unsubscribe = () => {};
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        if (heartbeat) clearInterval(heartbeat);
+        unsubscribe();
+        req.signal?.removeEventListener("abort", cleanup);
+        try { controller.close(); } catch { /* already closed/cancelled */ }
+      };
+      dispose = cleanup;
+      req.signal?.addEventListener("abort", cleanup);
       const encode = (data: unknown) => {
+        if (closed) return false;
         const text = `data: ${JSON.stringify(data)}\n\n`;
-        controller.enqueue(encoder.encode(text));
+        try {
+          controller.enqueue(encoder.encode(text));
+          return true;
+        } catch {
+          cleanup();
+          return false;
+        }
       };
 
       // Subscribe BEFORE taking the initial snapshot so no state change can slip
       // through the gap between snapshot and subscription.
-      const unsubscribe = subscribeRunningSessions((ids) => {
-        try {
-          encode({ type: "running", runningSessionIds: ids });
-        } catch {
-          // controller already closed
-        }
+      const nextUnsubscribe = subscribeRunningSessions((ids) => {
+        encode({ type: "running", runningSessionIds: ids });
       });
+      if (closed) nextUnsubscribe();
+      else unsubscribe = nextUnsubscribe;
 
       // Initial snapshot so the client renders the correct state immediately.
       // (A duplicate frame here is harmless: the client just sets the same set.)
       encode({ type: "running", runningSessionIds: getRunningRpcSessionIds() });
 
       // Heartbeat to keep the connection alive through proxies/timeouts.
-      const heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(":\n\n"));
-        } catch {
-          // controller already closed
-        }
+      if (!closed) heartbeat = setInterval(() => {
+        if (closed) return;
+        try { controller.enqueue(encoder.encode(":\n\n")); }
+        catch { cleanup(); }
       }, 30_000);
 
-      const cleanup = () => {
-        clearInterval(heartbeat);
-        unsubscribe();
-        try { controller.close(); } catch { /* already closed */ }
-      };
-
-      req.signal?.addEventListener("abort", cleanup);
+    },
+    cancel() {
+      dispose();
     },
   });
 

--- a/app/api/auth/login/[provider]/route.ts
+++ b/app/api/auth/login/[provider]/route.ts
@@ -50,7 +50,15 @@ export async function GET(
 
   const encoder = new TextEncoder();
   const send = (controller: ReadableStreamDefaultController, data: unknown) => {
-    controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+    try {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const close = (controller: ReadableStreamDefaultController) => {
+    try { controller.close(); } catch { /* already closed/cancelled */ }
   };
 
   // AbortController propagates client disconnect into ModelRuntime.login().
@@ -62,7 +70,7 @@ export async function GET(
       const modelRuntime = await ModelRuntime.create();
       if (!modelRuntime.getProvider(provider)?.auth.oauth) {
         send(controller, { type: "error", message: `Unknown provider: ${provider}` });
-        controller.close();
+        close(controller);
         return;
       }
 
@@ -174,7 +182,7 @@ export async function GET(
         }
       } finally {
         cleanup();
-        controller.close();
+        close(controller);
       }
     },
     cancel() {

--- a/app/api/desktop/identity/route.test.mjs
+++ b/app/api/desktop/identity/route.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import { createJiti } from "jiti";
+
+const envName = "PI_DESKTOP_INSTANCE_ID";
+const originalInstanceId = process.env[envName];
+const { GET } = await createJiti(import.meta.url, { tsconfigPaths: true })
+  .import("./route.ts");
+
+afterEach(() => {
+  if (originalInstanceId === undefined) delete process.env[envName];
+  else process.env[envName] = originalInstanceId;
+});
+
+test("desktop identity is unavailable outside a packaged server", async () => {
+  delete process.env[envName];
+  const response = await GET();
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get("x-pi-desktop-instance"), null);
+});
+
+test("desktop identity returns only the packaged instance id header", async () => {
+  process.env[envName] = "test-instance-id";
+  const response = await GET();
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("x-pi-desktop-instance"), "test-instance-id");
+  assert.equal(await response.text(), "");
+});

--- a/app/api/desktop/identity/route.ts
+++ b/app/api/desktop/identity/route.ts
@@ -1,0 +1,25 @@
+import {
+  DESKTOP_INSTANCE_ID_ENV,
+  DESKTOP_INSTANCE_ID_HEADER,
+} from "@/lib/desktop-api";
+
+export const dynamic = "force-dynamic";
+
+// The packaged shell probes this endpoint before it creates the WebView. The
+// random id is separate from the desktop API token: it proves that the server
+// on the selected port is the child this process just spawned without exposing
+// a filesystem authorization credential over HTTP.
+export async function GET() {
+  const instanceId = process.env[DESKTOP_INSTANCE_ID_ENV]?.trim();
+  if (!instanceId) {
+    return new Response(null, { status: 404 });
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: {
+      [DESKTOP_INSTANCE_ID_HEADER]: instanceId,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from "next/server";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import path from "path";
-import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { loadSkillsWithInstallInfo } from "@/lib/skills-service";
 import { getAllowedFileRoots, isExistingFilePathAllowed } from "@/lib/file-access";
+import { setSkillModelInvocationDisabled } from "@/lib/skill-frontmatter";
 
 export const dynamic = "force-dynamic";
 
@@ -47,23 +48,7 @@ export async function PATCH(req: Request) {
     }
 
     const content = readFileSync(filePath, "utf8");
-    const key = "disable-model-invocation";
-
-    // Use parseFrontmatter to check current value, then do a surgical line edit
-    // to preserve the original YAML formatting of all other fields.
-    const { frontmatter } = parseFrontmatter<Record<string, unknown>>(content);
-    const alreadySet = Boolean(frontmatter[key]);
-
-    let updated = content;
-    if (disableModelInvocation && !alreadySet) {
-      // Add key after the opening --- line
-      updated = content.replace(/^---\r?\n/, `---\n${key}: true\n`);
-      // If no frontmatter exists, create one
-      if (updated === content) updated = `---\n${key}: true\n---\n${content}`;
-    } else if (!disableModelInvocation && alreadySet) {
-      // Remove the key line entirely
-      updated = content.replace(new RegExp(`^${key}\\s*:.*\\r?\\n`, "m"), "");
-    }
+    const updated = setSkillModelInvocationDisabled(content, disableModelInvocation);
 
     writeFileSync(filePath, updated, "utf8");
     return NextResponse.json({ success: true });

--- a/components/FileExplorer-cache.test.mjs
+++ b/components/FileExplorer-cache.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./FileExplorer.tsx", import.meta.url), "utf8");
+
+test("collapsed loaded directories become stale and reload when expanded", () => {
+  const nodeSource = source.slice(
+    source.indexOf("function TreeNode("),
+    source.indexOf("function SearchResultRow("),
+  );
+  assert.match(nodeSource, /const staleRef = useRef\(false\)/);
+  assert.match(nodeSource, /lastRefreshTokenRef\.current === refreshToken/);
+  assert.match(nodeSource, /if \(loading\) staleRef\.current = true/);
+  assert.match(nodeSource, /else \{\s*staleRef\.current = true;/);
+  assert.match(nodeSource, /open && !loading && \(!loaded \|\| staleRef\.current\)/);
+  assert.match(nodeSource, /const force = loaded;[\s\S]*?loadChildren\(force\)/);
+});

--- a/components/FileExplorer.tsx
+++ b/components/FileExplorer.tsx
@@ -262,6 +262,8 @@ function TreeNode({
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [hovered, setHovered] = useState(false);
+  const staleRef = useRef(false);
+  const lastRefreshTokenRef = useRef(refreshToken);
 
   const loadChildren = useCallback(async (force = false) => {
     if (loaded && !force) return;
@@ -278,18 +280,33 @@ function TreeNode({
     }
   }, [loaded, node.fullPath]);
 
-  // Re-fetch children when the tree refreshes and the directory is open.
+  // Refresh open directories immediately. Collapsed directory components keep
+  // their local children cache, so remember that they missed this refresh and
+  // force a reload the next time they are expanded.
   useEffect(() => {
+    if (lastRefreshTokenRef.current === refreshToken) return;
+    lastRefreshTokenRef.current = refreshToken;
+    if (!loaded) {
+      // A request that started before this refresh may still complete with an
+      // old listing. Make the next expansion verify it once more.
+      if (loading) staleRef.current = true;
+      return;
+    }
     if (open && loaded) {
-      loadChildren(true);
+      staleRef.current = false;
+      void loadChildren(true);
+    } else {
+      staleRef.current = true;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshToken]);
 
-  // Programmatic expand (e.g. after uploading into a collapsed folder) must load children.
+  // Both click and programmatic expansion pass through this effect.
   useEffect(() => {
-    if (open && !loaded && !loading) {
-      void loadChildren();
+    if (open && !loading && (!loaded || staleRef.current)) {
+      const force = loaded;
+      staleRef.current = false;
+      void loadChildren(force);
     }
   }, [open, loaded, loading, loadChildren]);
 
@@ -298,11 +315,10 @@ function TreeNode({
     if (node.isDir) {
       const next = !open;
       onToggleExpanded(node.fullPath, next);
-      if (next && !loaded) loadChildren();
     } else {
       onOpenFile(node.fullPath, node.name);
     }
-  }, [node.isDir, node.fullPath, node.name, loaded, open, loadChildren, onOpenFile, onSelectPath, onToggleExpanded]);
+  }, [node.isDir, node.fullPath, node.name, open, onOpenFile, onSelectPath, onToggleExpanded]);
 
   const handleDragEnter = useCallback((event: React.DragEvent) => {
     if (!hasDraggedFiles(event) || uploadBusy) return;

--- a/components/useAgentSession-session-isolation.test.mjs
+++ b/components/useAgentSession-session-isolation.test.mjs
@@ -30,6 +30,17 @@ test("tool preset loads ignore stale sessions and out-of-order responses", async
   assert.match(body, /tools && isCurrent\(\)/);
 });
 
+test("agent-end state refreshes cannot overwrite a switched session or newer run", async () => {
+  const source = await readFile(sourceUrl, "utf8");
+  const body = functionSlice(source, 'case "agent_end"', 'case "agent_settled"');
+  assert.match(body, /const sid = sessionIdRef\.current/);
+  assert.match(body, /const sessionGeneration = sessionGenerationRef\.current/);
+  assert.match(body, /const runId = promptRunIdRef\.current/);
+  assert.match(body, /sessionIdRef\.current !== sid/);
+  assert.match(body, /sessionGenerationRef\.current !== sessionGeneration/);
+  assert.match(body, /promptRunIdRef\.current !== runId/);
+});
+
 test("a stale branch load cannot navigate the newly active session", async () => {
   const source = await readFile(sourceUrl, "utf8");
   const body = functionSlice(source, "const handleLeafChange = useCallback", "const handleModelChange = useCallback");

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -50,6 +50,8 @@ test("keeps the session event stream open through the idle grace window", () => 
   assert.match(promptDoneSource, /scheduleEventStreamClose\(sid\)/);
   assert.match(sendSource, /if \(promptRequestStarted && sentSessionId\) \{[\s\S]*?waitForPromptSettlement/);
   assert.match(sendSource, /if \(promptRequestStarted && sentSessionId\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?closeEvents\(\)/);
+  assert.match(sendSource, /opts\.chatInputRef\?\.current\?\.replaceMessage\(userMsg\)/);
+  assert.doesNotMatch(sendSource, /if \(e instanceof EventStreamConnectionError\)/);
 });
 
 test("reuses an open event stream and hides an empty agent phase", () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -8,6 +8,7 @@ import type {
   ExtensionWidgetItem,
   SessionInfo,
   SessionTreeNode,
+  UserMessage,
 } from "@/lib/types";
 import { normalizeToolCalls } from "@/lib/normalize";
 import { sendAgentCommand } from "@/lib/agent-client";
@@ -314,6 +315,7 @@ function readCompactResult(result: unknown, reason: string): CompactResultInfo |
 export interface ChatInputHandle {
   insertText: (text: string) => void;
   insertIfEmpty: (content: string) => void;
+  replaceMessage: (message: UserMessage) => void;
   prependText: (text: string) => void;
   addImages: (files: File[]) => void;
   focus: () => void;
@@ -462,6 +464,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   // switches A → B → A before the first A request settles.
   const contextLoadIdRef = useRef(0);
   const toolsLoadIdRef = useRef(0);
+  const sessionGenerationRef = useRef(0);
   const agentRunningRef = useRef(false);
   const sdkAgentActiveRef = useRef(false);
   const rpcPromptPendingRef = useRef(false);
@@ -529,6 +532,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       newSessionPromotedRef.current = false;
       contextLoadIdRef.current += 1;
       toolsLoadIdRef.current += 1;
+      sessionGenerationRef.current += 1;
       agentRunningRef.current = false;
       bashRunningRef.current = false;
       initialScrollDoneRef.current = false;
@@ -1252,10 +1256,21 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
         setRetryInfo(null);
         dispatch({ type: "end" });
         if (sessionIdRef.current) {
-          loadSession(sessionIdRef.current);
-          fetch(`/api/agent/${encodeURIComponent(sessionIdRef.current)}`)
-            .then((r) => r.json())
+          const sid = sessionIdRef.current;
+          const sessionGeneration = sessionGenerationRef.current;
+          const runId = promptRunIdRef.current;
+          void loadSession(sid);
+          fetch(`/api/agent/${encodeURIComponent(sid)}`)
+            .then((r) => {
+              if (!r.ok) throw new Error(`HTTP ${r.status}`);
+              return r.json();
+            })
             .then((d: { state?: AgentStateResponse }) => {
+              if (
+                sessionIdRef.current !== sid
+                || sessionGenerationRef.current !== sessionGeneration
+                || promptRunIdRef.current !== runId
+              ) return;
               if (d.state?.contextUsage !== undefined) setContextUsage(d.state.contextUsage ?? null);
               if (d.state?.systemPrompt !== undefined) setSystemPrompt(d.state.systemPrompt ?? null);
               if (d.state?.extensionStatuses !== undefined) setExtensionStatuses(d.state.extensionStatuses ?? []);
@@ -1462,7 +1477,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     rpcPromptPendingRef.current = true;
 
     const imageBlocks = images?.map((img) => ({ type: "image" as const, source: { type: "base64" as const, media_type: img.mimeType, data: img.data } }));
-    const userMsg: AgentMessage = {
+    const userMsg: UserMessage = {
       role: "user",
       content: imageBlocks?.length
         ? [...(message.trim() ? [{ type: "text" as const, text: message }] : []), ...imageBlocks]
@@ -1532,25 +1547,28 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       rpcPromptPendingRef.current = false;
       agentRunningRef.current = false;
       closeEvents();
-      if (e instanceof EventStreamConnectionError) {
-        const optimisticKey = optimisticUserMessageKeyRef.current;
-        if (optimisticKey) {
-          setMessages((prev) => {
-            const last = prev[prev.length - 1];
-            return last?.role === "user" && userMessageKey(last) === optimisticKey
-              ? prev.slice(0, -1)
-              : prev;
-          });
-        }
-        addNotice({ type: "error", message: e.message });
-        // The prompt never reached the agent, so restore the user's text into
-        // the input instead of losing it. Mirrors the shell-command recovery in
-        // executeBash; insertIfEmpty avoids clobbering anything typed since.
-        if (message) opts.chatInputRef?.current?.insertIfEmpty(message);
+      const optimisticKey = optimisticUserMessageKeyRef.current;
+      if (optimisticKey) {
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          return last?.role === "user" && userMessageKey(last) === optimisticKey
+            ? prev.slice(0, -1)
+            : prev;
+        });
       }
+      addNotice({
+        type: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+      // No prompt request started, so the complete optimistic message is safe
+      // to restore. replaceMessage preserves image attachments and refuses to
+      // overwrite anything the user typed while startup was failing.
+      opts.chatInputRef?.current?.replaceMessage(userMsg);
       optimisticUserMessageKeyRef.current = null;
       setAgentRunning(false);
       setAgentPhase(null);
+      pendingScrollToUserRef.current = false;
+      setPromptAnchorActive(false);
       dispatch({ type: "end" });
     }
   }, [isNew, newSessionCwd, newSessionModel, session, ensureNewSession, ensureEventsConnected, promoteNewSession, waitForPromptSettlement, addNotice, cancelEventStreamGrace, closeEvents, dispatch, opts.chatInputRef]);

--- a/lib/desktop-api-contract.test.mjs
+++ b/lib/desktop-api-contract.test.mjs
@@ -20,9 +20,10 @@ test("every native-dialog filesystem route requires desktop authorization", asyn
 });
 
 test("desktop token crosses only the Tauri command and process environment contract", async () => {
-  const [native, rust, capability, permissions, packageJson] = await Promise.all([
+  const [native, rust, identityRoute, capability, permissions, packageJson] = await Promise.all([
     source("lib/desktop-native.ts"),
     source("src-tauri/src/lib.rs"),
+    source("app/api/desktop/identity/route.ts"),
     source("src-tauri/capabilities/desktop-dialog.json"),
     source("src-tauri/permissions/desktop-shell.toml"),
     source("package.json"),
@@ -31,6 +32,10 @@ test("desktop token crosses only the Tauri command and process environment contr
   assert.match(native, /invoke<string>\("get_desktop_api_token"\)/);
   assert.match(native, /headers\.set\(DESKTOP_API_TOKEN_HEADER/);
   assert.match(rust, /\.env\(DESKTOP_API_TOKEN_ENV, desktop_api_token\)/);
+  assert.match(rust, /\.env\(DESKTOP_INSTANCE_ID_ENV, desktop_instance_id\)/);
+  assert.match(rust, /server_identity_matches\(address, expected_instance_id\)/);
+  assert.match(identityRoute, /DESKTOP_INSTANCE_ID_HEADER/);
+  assert.match(identityRoute, /status: 204/);
   assert.match(rust, /fn get_desktop_api_token/);
   assert.match(capability, /allow-get-desktop-api-token/);
   assert.match(permissions, /commands\.allow = \["get_desktop_api_token"\]/);

--- a/lib/desktop-api.ts
+++ b/lib/desktop-api.ts
@@ -1,3 +1,5 @@
 export const DESKTOP_API_TOKEN_ENV = "PI_DESKTOP_API_TOKEN";
 export const DESKTOP_API_TOKEN_HEADER = "x-pi-desktop-token";
+export const DESKTOP_INSTANCE_ID_ENV = "PI_DESKTOP_INSTANCE_ID";
+export const DESKTOP_INSTANCE_ID_HEADER = "x-pi-desktop-instance";
 export const MAX_DESKTOP_SAVE_BYTES = 100 * 1024 * 1024;

--- a/lib/draft-store.test.mjs
+++ b/lib/draft-store.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { createJiti } from "jiti";
+
+const storage = new Map();
+globalThis.window = {
+  localStorage: {
+    getItem(key) { return storage.get(key) ?? null; },
+    setItem(key, value) { storage.set(key, value); },
+    removeItem(key) { storage.delete(key); },
+  },
+};
+
+const { setDraft } = await createJiti(import.meta.url, { tsconfigPaths: true })
+  .import("./draft-store.ts");
+
+after(() => {
+  delete globalThis.window;
+});
+
+test("the persistence cap keeps the most recently edited drafts", async () => {
+  for (let index = 0; index < 41; index++) {
+    setDraft(`session-${index}`, { value: `draft-${index}`, images: [] });
+  }
+  setDraft("session-0", { value: "edited-most-recently", images: [] });
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const persisted = JSON.parse(storage.get("pi-chat-drafts-v1"));
+  assert.equal(Object.keys(persisted).length, 40);
+  assert.equal(persisted["session-0"].value, "edited-most-recently");
+  assert.equal(persisted["session-1"], undefined);
+});

--- a/lib/draft-store.ts
+++ b/lib/draft-store.ts
@@ -82,6 +82,9 @@ export function setDraft(key: string, draft: ChatDraft): void {
     schedulePersist();
     return;
   }
+  // Map.set() does not refresh insertion order for an existing key. Delete it
+  // first so the persistence cap below keeps the most recently edited drafts.
+  drafts.delete(key);
   drafts.set(key, cloneDraft(draft));
   schedulePersist();
 }

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -72,6 +72,18 @@ test("RPC wrapper avoids per-chunk idle and running-state maintenance", async ()
   assert.match(notifySource, /lastRunningSnapshot = ""/);
 });
 
+test("RPC wrapper isolates event listener failures", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const emitSource = source.slice(
+    source.indexOf("  private emit(event: AgentEvent)"),
+    source.indexOf("  private resetIdleTimer"),
+  );
+
+  assert.match(emitSource, /for \(const listener of this\.listeners\)/);
+  assert.match(emitSource, /try \{\s*listener\(event\);/);
+  assert.match(emitSource, /catch \(error\)/);
+});
+
 test("normal session teardown paths use graceful extension shutdown", async () => {
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const deleteRouteSource = await readFile(new URL("../app/api/sessions/[id]/route.ts", import.meta.url), "utf8");

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -356,7 +356,15 @@ export class AgentSessionWrapper {
   }
 
   private emit(event: AgentEvent): void {
-    for (const l of this.listeners) l(event);
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        // A disconnected SSE client must not prevent the remaining listeners
+        // or the running-session notification path from receiving this event.
+        console.error("Agent session event listener failed:", error);
+      }
+    }
   }
 
   private resetIdleTimer(): void {

--- a/lib/skill-frontmatter.test.mjs
+++ b/lib/skill-frontmatter.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { setSkillModelInvocationDisabled } = await jiti.import("./skill-frontmatter.ts");
+
+test("adds and removes the model-invocation flag without touching other YAML", () => {
+  const source = "---\nname: demo\ndescription: keep formatting\n---\nBody\n";
+  const disabled = setSkillModelInvocationDisabled(source, true);
+  assert.equal(
+    disabled,
+    "---\ndisable-model-invocation: true\nname: demo\ndescription: keep formatting\n---\nBody\n",
+  );
+  assert.equal(setSkillModelInvocationDisabled(disabled, false), source);
+});
+
+test("replaces explicit false and repairs duplicate keys", () => {
+  const explicitFalse = "---\nname: demo\ndisable-model-invocation: false\n---\n";
+  assert.equal(
+    setSkillModelInvocationDisabled(explicitFalse, true),
+    "---\nname: demo\ndisable-model-invocation: true\n---\n",
+  );
+
+  const duplicate = "---\ndisable-model-invocation: true\nname: demo\ndisable-model-invocation: false\n---\n";
+  const repaired = setSkillModelInvocationDisabled(duplicate, true);
+  assert.equal((repaired.match(/^disable-model-invocation:/gm) ?? []).length, 1);
+  assert.match(repaired, /^disable-model-invocation: true$/m);
+  assert.equal(
+    setSkillModelInvocationDisabled(duplicate, false),
+    "---\nname: demo\n---\n",
+  );
+});
+
+test("preserves CRLF and creates frontmatter when needed", () => {
+  const source = "---\r\nname: demo\r\ndisable-model-invocation: false\r\n---\r\nBody\r\n";
+  const updated = setSkillModelInvocationDisabled(source, true);
+  assert.equal(updated.replaceAll("\r\n", "").includes("\n"), false);
+  assert.match(updated, /disable-model-invocation: true\r\n/);
+  assert.equal(
+    setSkillModelInvocationDisabled("Body\n", true),
+    "---\ndisable-model-invocation: true\n---\nBody\n",
+  );
+  assert.equal(setSkillModelInvocationDisabled("Body\n", false), "Body\n");
+});

--- a/lib/skill-frontmatter.ts
+++ b/lib/skill-frontmatter.ts
@@ -1,0 +1,58 @@
+const DISABLE_MODEL_INVOCATION_KEY = "disable-model-invocation";
+
+type FrontmatterParts = {
+  opening: string;
+  yaml: string;
+  closing: string;
+  rest: string;
+  newline: "\n" | "\r\n";
+};
+
+function splitFrontmatter(content: string): FrontmatterParts | null {
+  const match = /^(---)(\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/.exec(content);
+  if (!match) return null;
+  return {
+    opening: `${match[1]}${match[2]}`,
+    yaml: match[3],
+    closing: match[4],
+    rest: content.slice(match[0].length),
+    newline: match[2] as "\n" | "\r\n",
+  };
+}
+
+/**
+ * Surgically updates the one frontmatter key owned by the skills UI.
+ * Existing duplicate lines are collapsed so files written by older versions
+ * become parseable again, while all unrelated YAML formatting is preserved.
+ */
+export function setSkillModelInvocationDisabled(
+  content: string,
+  disabled: boolean,
+): string {
+  const parts = splitFrontmatter(content);
+  if (!parts) {
+    if (!disabled) return content;
+    const newline = content.includes("\r\n") ? "\r\n" : "\n";
+    return `---${newline}${DISABLE_MODEL_INVOCATION_KEY}: true${newline}---${newline}${content}`;
+  }
+
+  const keyLine = new RegExp(
+    `^${DISABLE_MODEL_INVOCATION_KEY}[ \\t]*:.*(?:\\r?\\n|$)`,
+    "gm",
+  );
+  let found = false;
+  let yaml = parts.yaml.replace(keyLine, () => {
+    if (!disabled || found) return "";
+    found = true;
+    return `${DISABLE_MODEL_INVOCATION_KEY}: true${parts.newline}`;
+  });
+
+  if (disabled && !found) {
+    yaml = `${DISABLE_MODEL_INVOCATION_KEY}: true${parts.newline}${yaml}`;
+  } else if (yaml.endsWith(parts.newline)) {
+    // The closing delimiter already owns the separator newline.
+    yaml = yaml.slice(0, -parts.newline.length);
+  }
+
+  return `${parts.opening}${yaml}${parts.closing}${parts.rest}`;
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     fs::{self, OpenOptions},
-    io,
+    io::{self, Read, Write},
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
@@ -24,6 +24,8 @@ use tauri::{
 
 const WINDOW_LABEL: &str = "main";
 const DESKTOP_API_TOKEN_ENV: &str = "PI_DESKTOP_API_TOKEN";
+const DESKTOP_INSTANCE_ID_ENV: &str = "PI_DESKTOP_INSTANCE_ID";
+const DESKTOP_INSTANCE_ID_HEADER: &str = "x-pi-desktop-instance";
 #[cfg(not(feature = "custom-protocol"))]
 const DEV_SERVER_URL: &str = "http://127.0.0.1:30141";
 /// Preferred localhost port for the packaged Next server. Keeping this stable
@@ -47,17 +49,21 @@ struct CloseQuits(Mutex<bool>);
 
 struct DesktopApiToken(String);
 
-fn load_or_generate_desktop_api_token() -> Result<String, String> {
-    if let Ok(token) = env::var(DESKTOP_API_TOKEN_ENV) {
-        let token = token.trim();
-        if token.len() >= 32 {
-            return Ok(token.to_string());
-        }
-    }
-
+fn generate_random_hex() -> Result<String, String> {
     let mut bytes = [0_u8; 32];
     getrandom::fill(&mut bytes).map_err(|error| error.to_string())?;
     Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn load_or_generate_desktop_api_token() -> Result<String, String> {
+    if let Ok(value) = env::var(DESKTOP_API_TOKEN_ENV) {
+        let value = value.trim();
+        if value.len() >= 32 {
+            return Ok(value.to_string());
+        }
+    }
+
+    generate_random_hex()
 }
 
 #[tauri::command]
@@ -304,9 +310,8 @@ fn show_main_window_cmd(app: AppHandle) -> Result<(), String> {
 /// user's light/dark choice even when the local server port changes.
 #[tauri::command]
 fn set_ui_theme(app: AppHandle, theme: String) -> Result<(), String> {
-    let theme = normalize_theme(&theme).ok_or_else(|| {
-        "theme must be \"light\" or \"dark\"".to_string()
-    })?;
+    let theme =
+        normalize_theme(&theme).ok_or_else(|| "theme must be \"light\" or \"dark\"".to_string())?;
     write_ui_prefs_theme(&app, theme)?;
     apply_window_theme(&app, theme);
     Ok(())
@@ -558,18 +563,89 @@ fn choose_port(app: &AppHandle) -> io::Result<u16> {
 }
 
 #[cfg(feature = "custom-protocol")]
-fn wait_for_server(child: &mut Child, address: SocketAddr, log_path: &Path) -> io::Result<()> {
+fn response_has_instance_id(response: &[u8], expected_instance_id: &str) -> bool {
+    let Ok(response) = std::str::from_utf8(response) else {
+        return false;
+    };
+    let Some((headers, _)) = response.split_once("\r\n\r\n") else {
+        return false;
+    };
+    let mut lines = headers.lines();
+    let Some(status) = lines.next() else {
+        return false;
+    };
+    if !(status.starts_with("HTTP/1.1 204 ") || status.starts_with("HTTP/1.0 204 ")) {
+        return false;
+    }
+
+    lines.any(|line| {
+        line.split_once(':').is_some_and(|(name, value)| {
+            name.eq_ignore_ascii_case(DESKTOP_INSTANCE_ID_HEADER)
+                && value.trim() == expected_instance_id
+        })
+    })
+}
+
+#[cfg(feature = "custom-protocol")]
+fn server_identity_matches(address: SocketAddr, expected_instance_id: &str) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(&address, Duration::from_millis(200)) else {
+        return false;
+    };
+    let timeout = Some(Duration::from_millis(500));
+    if stream.set_read_timeout(timeout).is_err() || stream.set_write_timeout(timeout).is_err() {
+        return false;
+    }
+
+    let request = format!(
+        "GET /api/desktop/identity HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n"
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+
+    let mut response = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 512];
+    while response.len() < 8 * 1024 {
+        let Ok(read) = stream.read(&mut chunk) else {
+            return false;
+        };
+        if read == 0 {
+            break;
+        }
+        response.extend_from_slice(&chunk[..read]);
+        if response.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    response_has_instance_id(&response, expected_instance_id)
+}
+
+#[cfg(feature = "custom-protocol")]
+fn wait_for_server(
+    child: &mut Child,
+    address: SocketAddr,
+    expected_instance_id: &str,
+    log_path: &Path,
+) -> io::Result<()> {
     let deadline = Instant::now() + SERVER_START_TIMEOUT;
     while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok() {
-            return Ok(());
-        }
-
         if let Some(status) = child.try_wait()? {
             return Err(io::Error::other(format!(
                 "Pi Agent server exited early with {status}; see {}",
                 log_path.display()
             )));
+        }
+        if server_identity_matches(address, expected_instance_id) {
+            // Re-check after the HTTP handshake. A losing child can exit with
+            // EADDRINUSE while another process is answering on the same port.
+            if let Some(status) = child.try_wait()? {
+                return Err(io::Error::other(format!(
+                    "Pi Agent server exited during startup with {status}; see {}",
+                    log_path.display()
+                )));
+            }
+            return Ok(());
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -588,6 +664,7 @@ fn wait_for_server(child: &mut Child, address: SocketAddr, log_path: &Path) -> i
 fn start_packaged_server(
     app: &tauri::AppHandle,
     desktop_api_token: &str,
+    desktop_instance_id: &str,
 ) -> Result<(Url, DesktopServer), Box<dyn std::error::Error>> {
     let resource_dir = child_process_compatible_path(&app.path().resource_dir()?);
     let node_path = bundled_node_path(&resource_dir);
@@ -632,6 +709,7 @@ fn start_packaged_server(
         .env("NEXT_TELEMETRY_DISABLED", "1")
         .env("PI_WEB_PARENT_PID", std::process::id().to_string())
         .env(DESKTOP_API_TOKEN_ENV, desktop_api_token)
+        .env(DESKTOP_INSTANCE_ID_ENV, desktop_instance_id)
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
@@ -648,7 +726,7 @@ fn start_packaged_server(
     let mut child = command.spawn()?;
 
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    if let Err(error) = wait_for_server(&mut child, address, &log_path) {
+    if let Err(error) = wait_for_server(&mut child, address, desktop_instance_id, &log_path) {
         let server = DesktopServer::running(child);
         server.stop();
         return Err(error.into());
@@ -660,7 +738,7 @@ fn start_packaged_server(
 
 #[cfg(all(test, feature = "custom-protocol"))]
 mod tests {
-    use super::child_process_compatible_path;
+    use super::{child_process_compatible_path, response_has_instance_id};
     use std::path::{Path, PathBuf};
 
     #[cfg(windows)]
@@ -684,6 +762,18 @@ mod tests {
         let path = Path::new("/Applications/Pi Agent.app/Contents/Resources/server");
         assert_eq!(child_process_compatible_path(path), PathBuf::from(path));
     }
+
+    #[test]
+    fn packaged_server_handshake_requires_the_expected_instance_header() {
+        let expected = "instance-123";
+        let matching = b"HTTP/1.1 204 No Content\r\nx-pi-desktop-instance: instance-123\r\n\r\n";
+        let wrong = b"HTTP/1.1 204 No Content\r\nx-pi-desktop-instance: other\r\n\r\n";
+        let body_spoof = b"HTTP/1.1 204 No Content\r\nContent-Type: text/plain\r\n\r\ninstance-123";
+
+        assert!(response_has_instance_id(matching, expected));
+        assert!(!response_has_instance_id(wrong, expected));
+        assert!(!response_has_instance_id(body_spoof, expected));
+    }
 }
 
 #[cfg(not(feature = "custom-protocol"))]
@@ -697,8 +787,12 @@ fn start_development_server(
 pub fn run() {
     let desktop_api_token = load_or_generate_desktop_api_token()
         .expect("failed to create desktop API authorization token");
+    let desktop_instance_id =
+        generate_random_hex().expect("failed to create desktop server instance id");
     #[cfg(feature = "custom-protocol")]
     let server_api_token = desktop_api_token.clone();
+    #[cfg(feature = "custom-protocol")]
+    let server_instance_id = desktop_instance_id.clone();
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
@@ -732,7 +826,8 @@ pub fn run() {
             }
 
             #[cfg(feature = "custom-protocol")]
-            let (url, server) = start_packaged_server(app.handle(), &server_api_token)?;
+            let (url, server) =
+                start_packaged_server(app.handle(), &server_api_token, &server_instance_id)?;
             #[cfg(not(feature = "custom-protocol"))]
             let (url, server) = start_development_server(app.handle())?;
 


### PR DESCRIPTION
## Summary

- verify the packaged Node server with a per-process instance handshake before loading the Tauri WebView
- make agent, running-state, and OAuth SSE cleanup cancellation-safe and isolate failing session listeners
- restore complete unsent messages after startup failures and reject stale agent state refreshes across session/run boundaries
- update skill frontmatter without duplicate YAML keys and repair duplicates written by older versions
- invalidate collapsed file-tree caches after refreshes and persist chat drafts with LRU ordering

## Why

The affected paths had several independent lifecycle and cache-ordering gaps: a released desktop port could be claimed before Node listened, cancelled streams could throw through shared event dispatch, asynchronous session responses could outlive their owning UI state, and insertion-ordered caches/config edits did not match their intended semantics. Together these caused cross-instance desktop attachment, missing or stale UI state, lost drafts/messages, and malformed skill configuration.

## Issues

Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19

## Validation

- `npm test` — 408 tests passed
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 2 tests passed

`next build` was intentionally not run because the repository development notes prohibit it during development.
