### PR TITLE
fix: auto-close right panel when viewport too narrow

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -46,6 +46,7 @@ import {
   RIGHT_PANEL_MAX_WIDTH,
   RIGHT_PANEL_MIN_WIDTH,
   SIDEBAR_DEFAULT_WIDTH,
+  SPLIT_PANEL_MIN_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
 } from "@/lib/panel-layout";
@@ -159,6 +160,12 @@ export function AppShell() {
   useEffect(() => {
     if (isMobile) setSidebarOpen(false);
   }, [isMobile]);
+  // Close right panel when viewport is too narrow for split-panel layout
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (rightPanelOpen && window.innerWidth < SPLIT_PANEL_MIN_WIDTH)
+      setRightPanelOpen(false);
+  }, [rightPanelOpen]);
   useEffect(() => {
     setMobileSidebarReady(true);
   }, []);

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -160,12 +160,20 @@ export function AppShell() {
   useEffect(() => {
     if (isMobile) setSidebarOpen(false);
   }, [isMobile]);
-  // Close right panel when viewport is too narrow for split-panel layout
+  // Close right panel when viewport is too narrow for split-panel layout.
+  // Uses matchMedia's change event (not just the rightPanelOpen dependency)
+  // so it also fires when an already-open panel's viewport is resized narrow,
+  // not only when the panel itself is opened.
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (rightPanelOpen && window.innerWidth < SPLIT_PANEL_MIN_WIDTH)
-      setRightPanelOpen(false);
-  }, [rightPanelOpen]);
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(`(max-width: ${SPLIT_PANEL_MIN_WIDTH - 1}px)`);
+    const checkWidth = () => {
+      if (mql.matches) setRightPanelOpen(false);
+    };
+    checkWidth();
+    mql.addEventListener("change", checkWidth);
+    return () => mql.removeEventListener("change", checkWidth);
+  }, []);
   useEffect(() => {
     setMobileSidebarReady(true);
   }, []);


### PR DESCRIPTION
## 问题

当窗口宽度小于 960px 时，右侧面板（文件查看器）不会自动隐藏，导致与主内容区重叠。

## 解决方案

添加响应式逻辑，当 `window.innerWidth < SPLIT_PANEL_MIN_WIDTH (960px)` 时自动关闭右侧面板。

这与移动端自动关闭侧边栏的逻辑保持一致。

## 修改内容

- 在 `AppShell.tsx` 中添加 `SPLIT_PANEL_MIN_WIDTH` 的 import
- 添加 `useEffect` 监听窗口宽度，低于阈值时自动关闭右侧面板

## 测试

- 缩小窗口到 960px 以下，右侧面板应自动关闭
- 放大窗口后，需要手动重新打开面板