### PR TITLE
fix: keep bottom composer overlay from covering the chat scrollbar

### DIFF
--- a/app/native-theme.css
+++ b/app/native-theme.css
@@ -1830,6 +1830,11 @@ html.dark .sidebar-view-switcher-thumb {
 }
 
 .chat-input-shell {
+  /* Stop short of the scroll container's right-edge scrollbar gutter (see
+     scrollbarGutter: "stable both-edges" on .chat-window's scroll container)
+     so this full-width overlay doesn't paint over the scrollbar and fade it
+     out before it reaches the bottom. */
+  width: calc(100% - 8px);
   background:
     linear-gradient(to bottom, transparent, color-mix(in srgb, var(--bg) 94%, transparent) 18%) !important;
 }


### PR DESCRIPTION
## Summary
- The bottom composer overlay (`bottomComposerRef`, absolute, `inset-x-0`) spans the full width of the chat panel and sits above (z-20) the message scroll container.
- `.chat-input-shell`'s scrim background painted over the 8px scrollbar gutter reserved by `scrollbarGutter: "stable both-edges"`, fading the scrollbar out before it reached the bottom of the window.
- Fix: shrink `.chat-input-shell` to `calc(100% - 8px)` so its background stops short of the scrollbar gutter, leaving the scrollbar unobstructed down to the bottom.

## Test plan
- [x] Verified via DOM metrics in a live session: `.chat-input-shell` width is now 1272px inside a 1280px container (exactly 8px short), matching the reserved scrollbar gutter (`offsetWidth - clientWidth = 16px`, 8px per side).
- [ ] Manual visual check in the Electron app that the scrollbar thumb now renders fully down to the window bottom, not just in the browser preview pane (which doesn't render the custom `::-webkit-scrollbar` thumb visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)