### PR TITLE
Add context-usage ring next to model selector with session stats

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -26,7 +26,6 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { APP_PREF_KEYS, getPrefBool, getPrefJson, setPrefJson } from "@/lib/app-prefs";
 import { useViewportHeight } from "@/hooks/useViewportHeight";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
-import { copyText } from "@/lib/clipboard";
 import { useDesktopConnection } from "@/lib/desktop-connection";
 import { isTauriDesktop, setCloseQuitsNative } from "@/lib/desktop-native";
 import { getFileName } from "@/lib/file-paths";
@@ -54,8 +53,8 @@ import type { SessionInfo, SessionTreeNode } from "@/lib/types";
 import type { ProjectTrustStatus } from "@/lib/api-types";
 import type { ChatInputHandle } from "./ChatInput";
 import type { SessionStatsInfo } from "@/lib/pi-types";
+import { SessionStatsPanel } from "./SessionStatsPanel";
 
-type SessionCopyField = "file" | "id";
 type AutoNameStatus =
   | { kind: "idle" }
   | { kind: "naming" }
@@ -73,7 +72,7 @@ export function AppShell() {
   const [initialNavigation] = useState(() => resolveInitialNavigation(searchParams, persistedWorkspace));
   const [workspaceHydrated, setWorkspaceHydrated] = useState(() => !desktopMode);
   const { isDark, toggleTheme } = useTheme();
-  const { locale, t: translate } = useI18n();
+  const { t: translate } = useI18n();
   const isMobile = useIsMobile();
   useViewportHeight();
   const [selectedSession, setSelectedSession] = useState<SessionInfo | null>(null);
@@ -215,19 +214,10 @@ export function AppShell() {
   const handleSessionStatsChange = useCallback((stats: SessionStatsInfo | null) => {
     setSessionStats(stats);
   }, []);
-  const [copiedSessionField, setCopiedSessionField] = useState<SessionCopyField | null>(null);
-  const sessionCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const handleCopySessionField = useCallback((field: SessionCopyField, value: string) => {
-    void copyText(value).then(() => {
-      if (sessionCopyTimerRef.current) clearTimeout(sessionCopyTimerRef.current);
-      setCopiedSessionField(field);
-      sessionCopyTimerRef.current = setTimeout(() => setCopiedSessionField(null), 1400);
-    });
-  }, []);
+
 
   useEffect(() => {
     return () => {
-      if (sessionCopyTimerRef.current) clearTimeout(sessionCopyTimerRef.current);
       if (autoNameTimerRef.current) clearTimeout(autoNameTimerRef.current);
     };
   }, []);
@@ -1338,7 +1328,7 @@ export function AppShell() {
                           if (t && t.output > 0) parts.push(`↓${fmt(t.output)}`);
                           if (c > 0) parts.push(c >= 0.01 ? `$${c.toFixed(2)}` : "<$0.01");
                           if (contextUsage?.contextWindow && contextUsage.percent !== null) {
-                            parts.push(`${contextUsage.percent.toFixed(0)}% ctx`);
+                            parts.push(`${contextUsage.percent.toFixed(1)}% ctx`);
                           }
                           const summary = parts.length > 0 ? parts.join(" · ") : translate("appshell.statsHint");
                           return (
@@ -1414,158 +1404,11 @@ export function AppShell() {
                 </div>
               )}
               {activeTopPanel === "session" && (
-                <div className="session-info-popover" style={{
-                  background: "var(--surface-elevated)",
-                  borderBottom: "1px solid var(--border)",
-                  boxShadow: "var(--shadow-popover)",
-                  padding: "12px 16px",
-                }}>
-                  {sessionStats ? (() => {
-                    const sessionRows = [
-                       ...(sessionStats.sessionName ? [{ label: translate("session.name"), value: sessionStats.sessionName, copyField: null }] : []),
-                       { label: translate("session.file"), value: sessionStats.sessionFile ?? translate("session.inMemory"), copyField: "file" as const },
-                       { label: translate("session.id"), value: sessionStats.sessionId, copyField: "id" as const },
-                    ];
-                    const messageRows = [
-                       [translate("session.user"), sessionStats.userMessages.toLocaleString(locale)],
-                       [translate("session.assistant"), sessionStats.assistantMessages.toLocaleString(locale)],
-                       [translate("session.toolCalls"), sessionStats.toolCalls.toLocaleString(locale)],
-                       [translate("session.toolResults"), sessionStats.toolResults.toLocaleString(locale)],
-                       [translate("session.total"), sessionStats.totalMessages.toLocaleString(locale)],
-                    ];
-                    const tokenRows = [
-                       [translate("session.input"), sessionStats.tokens.input.toLocaleString(locale)],
-                       [translate("session.output"), sessionStats.tokens.output.toLocaleString(locale)],
-                       ...(sessionStats.tokens.cacheRead > 0 ? [[translate("session.cacheRead"), sessionStats.tokens.cacheRead.toLocaleString(locale)]] : []),
-                       ...(sessionStats.tokens.cacheWrite > 0 ? [[translate("session.cacheWrite"), sessionStats.tokens.cacheWrite.toLocaleString(locale)]] : []),
-                       [translate("session.total"), sessionStats.tokens.total.toLocaleString(locale)],
-                    ];
-                    const ctx = contextUsage ?? sessionStats.contextUsage;
-                    const formatCompact = (n: number) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1000 ? `${(n / 1000).toFixed(0)}k` : String(n);
-                    const extraTokenRows = [
-                       ...(sessionStats.cost > 0 ? [[translate("session.cost"), `$${sessionStats.cost.toFixed(4)}`]] : []),
-                       ...(ctx?.contextWindow ? [[translate("session.context"), `${ctx.percent !== null ? `${ctx.percent.toFixed(1)}%` : "?"} / ${formatCompact(ctx.contextWindow)}`]] : []),
-                    ];
-                    const section = (
-                      title: string,
-                      sectionRows: string[][],
-                      valueAlign: "left" | "right" = "left",
-                      compact = false,
-                    ) => (
-                        <div style={{ minWidth: 0 }}>
-                          <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>{title}</div>
-                          <div style={{
-                            display: "grid",
-                            gridTemplateColumns: compact ? "max-content max-content" : "auto minmax(0, 1fr)",
-                            columnGap: compact ? 14 : 12,
-                            rowGap: 4,
-                            justifyContent: compact ? "start" : undefined,
-                          }}>
-                            {sectionRows.map(([label, value]) => (
-                              <div key={`${title}:${label}`} style={{ display: "contents" }}>
-                                <div style={{ color: "var(--text-dim)", whiteSpace: "nowrap" }}>{label}</div>
-                                <div style={{
-                                  color: "var(--text-muted)",
-                                  minWidth: 0,
-                                  overflowWrap: compact ? "normal" : "anywhere",
-                                  textAlign: valueAlign,
-                                  whiteSpace: valueAlign === "right" ? "nowrap" : "normal",
-                                }}>{value}</div>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      );
-                    const copyButton = (field: SessionCopyField, value: string) => {
-                      const copied = copiedSessionField === field;
-                      return (
-                        <button
-                          type="button"
-                           title={copied ? translate("session.copied") : translate(field === "file" ? "session.copyFile" : "session.copyId")}
-                          onClick={() => handleCopySessionField(field, value)}
-                          style={{
-                            alignSelf: "start",
-                            display: "inline-flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            width: 22,
-                            height: 22,
-                            marginTop: -2,
-                            color: copied ? "var(--accent)" : "var(--text-dim)",
-                            background: "transparent",
-                            border: "1px solid var(--border)",
-                            borderRadius: 4,
-                            cursor: "pointer",
-                            flex: "0 0 auto",
-                            transition: "color 0.12s, border-color 0.12s, background 0.12s",
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.color = "var(--accent)";
-                            e.currentTarget.style.borderColor = "var(--accent)";
-                            e.currentTarget.style.background = "var(--bg-hover)";
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.color = copied ? "var(--accent)" : "var(--text-dim)";
-                            e.currentTarget.style.borderColor = "var(--border)";
-                            e.currentTarget.style.background = "transparent";
-                          }}
-                        >
-                          {copied ? (
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                              <polyline points="20 6 9 17 4 12" />
-                            </svg>
-                          ) : (
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                            </svg>
-                          )}
-                        </button>
-                      );
-                    };
-                    const sessionInfoSection = (
-                      <div style={{ minWidth: 0 }}>
-                         <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>{translate("session.infoSection")}</div>
-                        <div style={{ display: "grid", gridTemplateColumns: "auto minmax(0, 1fr) auto", columnGap: 12, rowGap: 8, alignItems: "start" }}>
-                          {sessionRows.map((row) => (
-                            <div key={`session-info:${row.label}`} style={{ display: "contents" }}>
-                              <div style={{ color: "var(--text-dim)", whiteSpace: "nowrap" }}>{row.label}</div>
-                              <div style={{
-                                color: "var(--text-muted)",
-                                minWidth: 0,
-                                overflowWrap: "anywhere",
-                                wordBreak: "break-word",
-                                whiteSpace: "normal",
-                              }}>{row.value}</div>
-                              <div>{row.copyField ? copyButton(row.copyField, row.value) : null}</div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    );
-
-                    return (
-                      <div style={{
-                        display: "grid",
-                        gridTemplateColumns: isMobile
-                          ? "1fr"
-                          : "minmax(360px, 1.7fr) minmax(140px, 0.55fr) minmax(190px, 0.75fr)",
-                        gap: isMobile ? 16 : 24,
-                        fontSize: 12,
-                        lineHeight: 1.5,
-                        fontFamily: "var(--font-mono)",
-                      }}>
-                        {sessionInfoSection}
-                         {section(translate("session.messages"), messageRows)}
-                         {section(translate("session.tokens"), [...tokenRows, ...extraTokenRows], "right", true)}
-                      </div>
-                    );
-                  })() : (
-                    <div style={{ fontSize: 12, color: "var(--text-muted)", fontStyle: "italic" }}>
-                       {translate("session.load")}
-                    </div>
-                  )}
-                </div>
+                <SessionStatsPanel
+                  sessionStats={sessionStats}
+                  contextUsage={contextUsage}
+                  isMobile={isMobile}
+                />
               )}
             </div>
           )}

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -23,7 +23,9 @@ import {
   selectFilesNative,
 } from "@/lib/desktop-native";
 import type { ExtensionStatusItem } from "@/lib/types";
+import type { ContextUsage } from "@/lib/pi-types";
 import { ExtensionStatusBar } from "./ExtensionStatusBar";
+import { ContextUsageRing } from "./ContextUsageRing";
 
 export interface AttachedImage {
   data: string;   // base64, no prefix
@@ -81,6 +83,10 @@ interface Props {
   autoFocus?: boolean;
   /** Extension footer statuses (tools/err/last, etc.) shown next to the model selector */
   extensionStatuses?: ExtensionStatusItem[];
+  /** Live context-window usage (numerator) for the usage ring next to the model selector */
+  contextUsage?: ContextUsage | null;
+  /** Open the top-bar session-stats panel when the usage ring is clicked */
+  onSessionStatsPanelOpen?: () => void;
 }
 
 export interface ChatInputHandle {
@@ -371,6 +377,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
   cwd,
   autoFocus = false,
   extensionStatuses = [],
+  contextUsage,
+  onSessionStatsPanelOpen,
 }: Props, ref) {
   const { t } = useI18n();
   const isMobile = useIsMobile();
@@ -2096,6 +2104,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput({
                   })()}
                 </div>
             )}
+            <ContextUsageRing contextUsage={contextUsage} onOpenStats={onSessionStatsPanelOpen} />
             <ExtensionStatusBar statuses={extensionStatuses} />
           </div>
 

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -848,6 +848,8 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       cwd={session?.cwd ?? newSessionCwd}
       autoFocus={isNew}
       extensionStatuses={extensionStatuses}
+      contextUsage={contextUsage}
+      onSessionStatsPanelOpen={onSessionStatsPanelOpen}
     />
   );
 

--- a/components/ContextUsageRing.tsx
+++ b/components/ContextUsageRing.tsx
@@ -1,0 +1,97 @@
+import { useI18n } from "@/hooks/useI18n";
+import type { ContextUsage } from "@/lib/pi-types";
+
+const RING_SIZE = 14;
+const RING_STROKE = 2;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+/** High-risk red threshold (fixed, Claude-convention). Single accent below it. */
+const CTX_DANGER_PCT = 90;
+
+function fmtWindow(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(n);
+}
+
+interface ContextUsageRingProps {
+  contextUsage?: ContextUsage | null;
+  /** Open the existing top-bar session-stats panel (AppShell openSessionStatsPanel). */
+  onOpenStats?: () => void;
+}
+
+/**
+ * Text-free usage ring next to the model selector (C1). The arc shows live
+ * context-window fullness in a single accent color; it turns red when usage
+ * reaches the high-risk threshold (≥90%). Hover shows the native HTML tooltip
+ * "percent · window"; click opens the top-bar session-stats panel.
+ *
+ * When there is no context usage yet (no session, or nothing has run), the ring
+ * renders dimmed and inert, and no title is set — no dead "Context usage"
+ * tooltip. Data only appears once the agent reports a context window.
+ */
+export function ContextUsageRing({ contextUsage, onOpenStats }: ContextUsageRingProps) {
+  const { t } = useI18n();
+
+  const hasUsage = contextUsage != null;
+  const percent = contextUsage?.percent ?? null;
+  const windowSize = contextUsage?.contextWindow ?? 0;
+  // A context window object always carries the denominator; percent may be
+  // unknown (null) right after a compaction until the next LLM response.
+  const showTooltip = hasUsage && (percent !== null || windowSize > 0);
+  const pct = percent !== null ? Math.max(0, Math.min(100, percent)) : 0;
+  const color = percent === null
+    ? "var(--text-dim)"
+    : pct >= CTX_DANGER_PCT
+      ? "var(--danger)"
+      : "var(--accent)";
+  const filled = RING_CIRCUMFERENCE * (pct / 100);
+
+  const title = showTooltip
+    ? (percent !== null ? `${percent.toFixed(1)}%` : "—") + ` / ${fmtWindow(windowSize)}`
+    : t("chat.ctxUsage");
+
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      title={showTooltip ? title : undefined}
+      aria-haspopup="dialog"
+      aria-disabled={!hasUsage}
+      onClick={() => {
+        if (hasUsage) onOpenStats?.();
+      }}
+      style={{
+        display: "flex", alignItems: "center", justifyContent: "center",
+        width: 28, height: 28, padding: 0, flexShrink: 0,
+        background: "none", border: "none", borderRadius: 9,
+        cursor: hasUsage ? "pointer" : "default",
+        transition: "background 0.12s, opacity 0.12s",
+        opacity: hasUsage ? 1 : 0.5,
+      }}
+      onMouseEnter={(e) => {
+        if (!hasUsage) return;
+        e.currentTarget.style.background = "var(--bg-hover)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = "none";
+      }}
+    >
+      <svg width={RING_SIZE} height={RING_SIZE} viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`} aria-hidden="true">
+        <circle cx={RING_SIZE / 2} cy={RING_SIZE / 2} r={RING_RADIUS} fill="none" stroke="var(--border)" strokeWidth={RING_STROKE} />
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={RING_RADIUS}
+          fill="none"
+          stroke={color}
+          strokeWidth={RING_STROKE}
+          strokeDasharray={`${filled} ${RING_CIRCUMFERENCE - filled}`}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+          opacity={percent === null ? 0.35 : 1}
+        />
+      </svg>
+    </button>
+  );
+}

--- a/components/SessionStatsPanel.tsx
+++ b/components/SessionStatsPanel.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useRef, useState } from "react";
+import { useI18n } from "@/hooks/useI18n";
+import { copyText } from "@/lib/clipboard";
+import type { ContextUsage, SessionStatsInfo } from "@/lib/pi-types";
+
+export type SessionCopyField = "file" | "id";
+
+interface SessionStatsPanelProps {
+  sessionStats: SessionStatsInfo | null;
+  contextUsage?: ContextUsage | null;
+  isMobile: boolean;
+}
+
+/**
+ * Reusable session-stats detail panel. Shared between the top-bar More →
+ * Session Stats entry (AppShell) and the context-usage ring popover next to
+ * the model selector (ChatInput). Copy feedback state is self-contained so
+ * both call sites behave independently.
+ */
+export function SessionStatsPanel({ sessionStats, contextUsage, isMobile }: SessionStatsPanelProps) {
+  const { locale, t: translate } = useI18n();
+  const [copiedSessionField, setCopiedSessionField] = useState<SessionCopyField | null>(null);
+  const sessionCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopySessionField = useCallback((field: SessionCopyField, value: string) => {
+    void copyText(value).then(() => {
+      if (sessionCopyTimerRef.current) clearTimeout(sessionCopyTimerRef.current);
+      setCopiedSessionField(field);
+      sessionCopyTimerRef.current = setTimeout(() => setCopiedSessionField(null), 1400);
+    });
+  }, []);
+
+  return (
+    <div className="session-info-popover" style={{
+      background: "var(--surface-elevated)",
+      borderBottom: "1px solid var(--border)",
+      boxShadow: "var(--shadow-popover)",
+      padding: "12px 16px",
+    }}>
+      {sessionStats ? (() => {
+        const sessionRows = [
+          ...(sessionStats.sessionName ? [{ label: translate("session.name"), value: sessionStats.sessionName, copyField: null }] : []),
+          { label: translate("session.file"), value: sessionStats.sessionFile ?? translate("session.inMemory"), copyField: "file" as const },
+          { label: translate("session.id"), value: sessionStats.sessionId, copyField: "id" as const },
+        ];
+        const messageRows = [
+          [translate("session.user"), sessionStats.userMessages.toLocaleString(locale)],
+          [translate("session.assistant"), sessionStats.assistantMessages.toLocaleString(locale)],
+          [translate("session.toolCalls"), sessionStats.toolCalls.toLocaleString(locale)],
+          [translate("session.toolResults"), sessionStats.toolResults.toLocaleString(locale)],
+          [translate("session.total"), sessionStats.totalMessages.toLocaleString(locale)],
+        ];
+        const tokenRows = [
+          [translate("session.input"), sessionStats.tokens.input.toLocaleString(locale)],
+          [translate("session.output"), sessionStats.tokens.output.toLocaleString(locale)],
+          ...(sessionStats.tokens.cacheRead > 0 ? [[translate("session.cacheRead"), sessionStats.tokens.cacheRead.toLocaleString(locale)]] : []),
+          ...(sessionStats.tokens.cacheWrite > 0 ? [[translate("session.cacheWrite"), sessionStats.tokens.cacheWrite.toLocaleString(locale)]] : []),
+          [translate("session.total"), sessionStats.tokens.total.toLocaleString(locale)],
+        ];
+        const ctx = contextUsage ?? sessionStats.contextUsage;
+        const formatCompact = (n: number) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1000 ? `${(n / 1000).toFixed(0)}k` : String(n);
+        const extraTokenRows = [
+          ...(sessionStats.cost > 0 ? [[translate("session.cost"), `$${sessionStats.cost.toFixed(4)}`]] : []),
+          ...(ctx?.contextWindow ? [[translate("session.context"), `${ctx.percent !== null ? `${ctx.percent.toFixed(1)}%` : "?"} / ${formatCompact(ctx.contextWindow)}`]] : []),
+        ];
+        const section = (
+          title: string,
+          sectionRows: string[][],
+          valueAlign: "left" | "right" = "left",
+          compact = false,
+        ) => (
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>{title}</div>
+              <div style={{
+                display: "grid",
+                gridTemplateColumns: compact ? "max-content max-content" : "auto minmax(0, 1fr)",
+                columnGap: compact ? 14 : 12,
+                rowGap: 4,
+                justifyContent: compact ? "start" : undefined,
+              }}>
+                {sectionRows.map(([label, value]) => (
+                  <div key={`${title}:${label}`} style={{ display: "contents" }}>
+                    <div style={{ color: "var(--text-dim)", whiteSpace: "nowrap" }}>{label}</div>
+                    <div style={{
+                      color: "var(--text-muted)",
+                      minWidth: 0,
+                      overflowWrap: compact ? "normal" : "anywhere",
+                      textAlign: valueAlign,
+                      whiteSpace: valueAlign === "right" ? "nowrap" : "normal",
+                    }}>{value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        const copyButton = (field: SessionCopyField, value: string) => {
+          const copied = copiedSessionField === field;
+          return (
+            <button
+              type="button"
+              title={copied ? translate("session.copied") : translate(field === "file" ? "session.copyFile" : "session.copyId")}
+              onClick={() => handleCopySessionField(field, value)}
+              style={{
+                alignSelf: "start",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 22,
+                height: 22,
+                marginTop: -2,
+                color: copied ? "var(--accent)" : "var(--text-dim)",
+                background: "transparent",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                cursor: "pointer",
+                flex: "0 0 auto",
+                transition: "color 0.12s, border-color 0.12s, background 0.12s",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = "var(--accent)";
+                e.currentTarget.style.borderColor = "var(--accent)";
+                e.currentTarget.style.background = "var(--bg-hover)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = copied ? "var(--accent)" : "var(--text-dim)";
+                e.currentTarget.style.borderColor = "var(--border)";
+                e.currentTarget.style.background = "transparent";
+              }}
+            >
+              {copied ? (
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              ) : (
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              )}
+            </button>
+          );
+        };
+        const sessionInfoSection = (
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text)", marginBottom: 6 }}>{translate("session.infoSection")}</div>
+            <div style={{ display: "grid", gridTemplateColumns: "auto minmax(0, 1fr) auto", columnGap: 12, rowGap: 8, alignItems: "start" }}>
+              {sessionRows.map((row) => (
+                <div key={`session-info:${row.label}`} style={{ display: "contents" }}>
+                  <div style={{ color: "var(--text-dim)", whiteSpace: "nowrap" }}>{row.label}</div>
+                  <div style={{
+                    color: "var(--text-muted)",
+                    minWidth: 0,
+                    overflowWrap: "anywhere",
+                    wordBreak: "break-word",
+                    whiteSpace: "normal",
+                  }}>{row.value}</div>
+                  <div>{row.copyField ? copyButton(row.copyField, row.value) : null}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+        return (
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: isMobile
+              ? "1fr"
+              : "minmax(360px, 1.7fr) minmax(140px, 0.55fr) minmax(190px, 0.75fr)",
+            gap: isMobile ? 16 : 24,
+            fontSize: 12,
+            lineHeight: 1.5,
+            fontFamily: "var(--font-mono)",
+          }}>
+            {sessionInfoSection}
+            {section(translate("session.messages"), messageRows)}
+            {section(translate("session.tokens"), [...tokenRows, ...extraTokenRows], "right", true)}
+          </div>
+        );
+      })() : (
+        <div style={{ fontSize: 12, color: "var(--text-muted)", fontStyle: "italic" }}>
+          {translate("session.load")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -230,6 +230,7 @@ export const enLocale: LocalePlugin = {
     "chat.compactContext": "Compact context",
     "chat.compacting": "Compacting…",
     "chat.compact": "Compact",
+    "chat.ctxUsage": "Context usage",
     "chat.stopAgent": "Stop agent",
     "chat.stop": "Stop",
     "chat.disableSound": "Disable completion sound",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -230,6 +230,7 @@ export const zhCNLocale: LocalePlugin = {
     "chat.compactContext": "压缩上下文",
     "chat.compacting": "正在压缩…",
     "chat.compact": "压缩",
+    "chat.ctxUsage": "上下文用量",
     "chat.stopAgent": "停止 Agent",
     "chat.stop": "停止",
     "chat.disableSound": "关闭完成提示音",


### PR DESCRIPTION
## What

Surface live context-window usage where it is actionable, instead of burying it in the top-bar **More → Session Stats** menu. Follows the Claude Code desktop pattern of a usage ring next to the model picker.

## Changes

- **New `ContextUsageRing`** component next to the model selector:
  - Text-free arc showing live context-window fullness.
  - Single accent color normally; turns red at ≥90% usage.
  - Hover shows the native HTML tooltip `39.6% / 1M` (percent · window).
  - Click opens the existing top-bar session-stats panel.
- **Extract `SessionStatsPanel`** from AppShell's inline JSX into a reusable component, shared by the More-menu entry and the ring's click-through (self-contained copy-feedback state).
- Wire `contextUsage` + `onSessionStatsPanelOpen` through ChatWindow → ChatInput.
- Align percent precision to one decimal everywhere (panel, tooltip, More summary).
- i18n: `chat.ctxUsage` (en / zh-CN).

## Design decisions (from grilling)

- Ring is text-free; only hover/click reveal data (no dead "Context usage" label when there is no data yet).
- Red threshold is a fixed 90% (Claude-convention) rather than pi's auto-compaction reserve line — tying red to the auto-compact trigger would make it invisible (auto-compaction resets the ring before it can be seen).
- No ADR recorded: reversible UI placement change, no domain terms crystallised.