### PR TITLE
fix(desktop): single-instance focus, fast quit, and theme-switch stability on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,8 @@ next-env.d.ts
 /src-tauri/resources/Pi Web Server.app/
 /src-tauri/resources/Pi Agent Server.app/
 /src-tauri/resources/server/
+/src-tauri/resources/node/
 /src-tauri/target/
+
+# pi agent local state
+/.pi/

--- a/app/api/files/[...path]/route.ts
+++ b/app/api/files/[...path]/route.ts
@@ -733,7 +733,13 @@ export async function GET(
             scheduleChange();
           };
           try {
-            watcher = fs.watch(filePath, { recursive: true }, handleEvent);
+            // Non-recursive on purpose: on Linux, recursive fs.watch walks the
+            // whole tree synchronously and stalls the event loop for seconds on
+            // large directories (breaks unrelated requests, e.g. the desktop
+            // health probe). The list endpoint renders a single level and file
+            // content changes are covered by the per-file `watch` above, so
+            // top-level entry events are enough; navigation re-lists as needed.
+            watcher = fs.watch(filePath, handleEvent);
           } catch {
             // Recursive watching may be unavailable on some platforms; fall
             // back to watching only the top-level directory.

--- a/components/PwaRegistration.tsx
+++ b/components/PwaRegistration.tsx
@@ -1,9 +1,24 @@
 "use client";
 
 import { useEffect } from "react";
+import { isTauriDesktop } from "@/lib/desktop-updater";
 
 export function PwaRegistration() {
   useEffect(() => {
+    // The desktop shell has no offline requirement, and a registered worker
+    // persists in the webview's origin-scoped cache across installs and can
+    // serve stale bundles. Skip registration and drop any previous worker.
+    if (isTauriDesktop()) {
+      if ("serviceWorker" in navigator) {
+        void navigator.serviceWorker
+          .getRegistrations()
+          .then((registrations) =>
+            registrations.forEach((registration) => void registration.unregister())
+          )
+          .catch(() => {});
+      }
+      return;
+    }
     if (process.env.NODE_ENV !== "production" || !("serviceWorker" in navigator)) {
       return;
     }

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -66,7 +66,10 @@ function applyTheme(next: Theme, animate: boolean) {
   }
 
   const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-  const supportsVT = typeof document.startViewTransition === "function";
+  // WebKitGTK crashes its UI process when startViewTransition is called, so the
+  // desktop shell keeps the existing instant-switch fallback.
+  const supportsVT =
+    !isTauriDesktop() && typeof document.startViewTransition === "function";
 
   if (!supportsVT || reduceMotion) {
     apply();

--- a/scripts/prepare-desktop.mjs
+++ b/scripts/prepare-desktop.mjs
@@ -20,11 +20,18 @@ async function runNextBuild() {
 
   await rm(desktopBuildDir, { recursive: true, force: true });
 
+  // The packaged server leaks its runtime config into spawned process trees
+  // via __NEXT_PRIVATE_STANDALONE_CONFIG; JSON drops function values, so an
+  // inherited build dies on `generateBuildId`. Always load config fresh.
+  const buildEnv = { ...process.env };
+  delete buildEnv.__NEXT_PRIVATE_STANDALONE_CONFIG;
+  delete buildEnv.__NEXT_PRIVATE_ORIGIN;
+
   await new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [nextBin, "build", "--webpack"], {
       cwd: rootDir,
       env: {
-        ...process.env,
+        ...buildEnv,
         NEXT_TELEMETRY_DISABLED: "1",
         PI_WEB_DESKTOP_BUILD: "1",
       },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -254,37 +254,47 @@ impl DesktopServer {
         let Ok(mut guard) = self.child.lock() else {
             return;
         };
-        let Some(mut child) = guard.take() else {
+        let Some(child) = guard.take() else {
             return;
         };
 
-        terminate_process_tree(&mut child);
+        terminate_process_tree(child);
     }
 }
 
-fn terminate_process_tree(child: &mut Child) {
+fn terminate_process_tree(mut child: Child) {
     #[cfg(unix)]
     {
+        let pid = child.id();
         unsafe {
             // The Node server owns its process group, so this also stops any
             // agent/tool subprocesses that are active when the App quits.
-            libc::kill(-(child.id() as i32), libc::SIGTERM);
+            libc::kill(-(pid as i32), libc::SIGTERM);
         }
 
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline {
-            match child.try_wait() {
-                Ok(Some(_)) => return,
-                Ok(None) => thread::sleep(Duration::from_millis(50)),
-                Err(_) => break,
+        // Reap on a detached thread so the quit/exit path never blocks on the
+        // Node server's shutdown. The packaged server installs no SIGTERM
+        // handler, so it normally dies immediately, but any child that ignores
+        // SIGTERM must not stall the UI for the full grace window. If the main
+        // process exits before this thread finishes, the server's own parent
+        // watchdog (desktop/server-launcher.cjs) exits it within ~1 s, so no
+        // orphan is left behind either way.
+        thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline {
+                match child.try_wait() {
+                    Ok(Some(_)) => return,
+                    Ok(None) => thread::sleep(Duration::from_millis(50)),
+                    Err(_) => return,
+                }
             }
-        }
 
-        unsafe {
-            libc::kill(-(child.id() as i32), libc::SIGKILL);
-        }
-        let _ = child.kill();
-        let _ = child.wait();
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        });
     }
 
     #[cfg(windows)]
@@ -541,10 +551,25 @@ fn theme_background_color(theme: &str) -> Color {
 
 fn theme_bootstrap_script(theme: &str) -> String {
     // Runs before page scripts so localStorage/class match the persisted
-    // preference even on a fresh webview origin (new localhost port).
+    // preference even on a fresh webview origin (new localhost port). The
+    // native pref is only seeded into localStorage when the origin has no
+    // choice recorded yet: the renderer writes "pi-theme" before it invokes
+    // `set_ui_theme`, so localStorage is always the freshest user intent and
+    // must never be clobbered by a (possibly stale) native pref — e.g. after
+    // a crash interrupted the toggle before the IPC round-trip landed.
     format!(
-        r#"(function(){{try{{localStorage.setItem("pi-theme","{theme}");var d="{theme}"==="dark";document.documentElement.classList.toggle("dark",d);document.documentElement.style.colorScheme=d?"dark":"light";}}catch(e){{}}}})();"#
+        r#"(function(){{try{{var t=localStorage.getItem("pi-theme");if(!t){{t="{theme}";localStorage.setItem("pi-theme",t);}}var d=t==="dark";document.documentElement.classList.toggle("dark",d);document.documentElement.style.colorScheme=d?"dark":"light";}}catch(e){{}}}})();"#
     )
+}
+
+/// True when running under a Wayland compositor. `set_background_color` and a
+/// few other native chrome APIs dereference a null GdkSurface there and crash,
+/// so callers consult this to avoid them.
+fn is_wayland() -> bool {
+    env::var("WAYLAND_DISPLAY").is_ok()
+        || env::var("GDK_BACKEND")
+            .map(|value| value.contains("wayland"))
+            .unwrap_or(false)
 }
 
 fn apply_window_theme(app: &AppHandle, theme: &str) {
@@ -557,7 +582,13 @@ fn apply_window_theme(app: &AppHandle, theme: &str) {
         Theme::Light
     };
     let _ = window.set_theme(Some(tauri_theme));
-    let _ = window.set_background_color(Some(theme_background_color(theme)));
+    // `set_background_color` dereferences a possibly-null GdkSurface under
+    // Wayland and segfaults the whole process (frameless WebKitGTK window).
+    // The page paints its own opaque background via CSS, so the native chrome
+    // color is cosmetic only and is safe to skip on Wayland.
+    if !is_wayland() {
+        let _ = window.set_background_color(Some(theme_background_color(theme)));
+    }
 }
 
 fn same_origin(candidate: &Url, app_url: &Url) -> bool {
@@ -604,8 +635,12 @@ fn build_window(app: &tauri::AppHandle, app_url: Url) -> tauri::Result<WebviewWi
         };
         builder = builder
             .theme(Some(tauri_theme))
-            .background_color(theme_background_color(theme))
             .initialization_script(theme_bootstrap_script(theme));
+        // Skip the native background color on Wayland: it can NULL-deref the
+        // GdkSurface during window creation and crash the process.
+        if !is_wayland() {
+            builder = builder.background_color(theme_background_color(theme));
+        }
     }
 
     // Hide the native title bar. macOS keeps the traffic-light controls
@@ -890,9 +925,7 @@ fn start_packaged_server(
 mod tests {
     use super::{child_process_compatible_path, response_has_instance_id};
     #[cfg(target_os = "linux")]
-    use super::{
-        visible_linux_tray_item, LinuxTray, LINUX_TRAY_QUIT_LABEL, LINUX_TRAY_SHOW_LABEL,
-    };
+    use super::{visible_linux_tray_item, LinuxTray, LINUX_TRAY_QUIT_LABEL, LINUX_TRAY_SHOW_LABEL};
     use std::path::{Path, PathBuf};
 
     #[cfg(windows)]
@@ -952,8 +985,175 @@ fn start_development_server(
     Ok((DEV_SERVER_URL.parse()?, DesktopServer::empty()))
 }
 
+/// Single-instance guard (Linux only). Launching the app binary again starts a
+/// brand-new process instead of focusing the running one, which left multiple
+/// server/window copies in the background. We claim a PID lock file; a later
+/// launch asks the live instance to raise its window via a request file and
+/// exits without starting another server. macOS already gets that behavior
+/// from the OS (LaunchServices + the `Reopen` handler below), and Windows has
+/// its own semantics, so this mechanism is intentionally Linux-scoped and
+/// keeps its `/proc`-based liveness probe off the other platforms.
+///
+/// Focus signalling deliberately uses a polled request file instead of a
+/// signal: JavaScriptCore owns SIGUSR1 on Linux (its GC suspension signal),
+/// and raising it from a second launch would land in JSC's GC handler and
+/// corrupt the process (SEGV).
+#[cfg(target_os = "linux")]
+const FOCUS_REQUEST_FILE: &str = "focus.request";
+
+#[cfg(target_os = "linux")]
+fn instance_lock_path() -> Option<PathBuf> {
+    let base = env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var("XDG_CONFIG_HOME")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| {
+            env::var("HOME")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|value| PathBuf::from(value).join(".config"))
+        });
+    base.map(|value| value.join("com.abcwyc.pi-agent").join("pi-agent.lock"))
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_our_app(pid: i32) -> bool {
+    fs::read_to_string(format!("/proc/{pid}/cmdline"))
+        .map(|content| {
+            let lowered = content.to_lowercase();
+            lowered.contains("pi-agent") || lowered.contains("pi agent")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn read_lock_pid(path: &Path) -> Option<i32> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i32>().ok())
+        .filter(|pid| *pid > 0)
+}
+
+/// Ask a live instance recorded in the lock file to raise its window, if any.
+#[cfg(target_os = "linux")]
+fn focus_existing_instance(path: &Path) -> bool {
+    if let Some(pid) = read_lock_pid(path) {
+        if process_is_our_app(pid) && unsafe { libc::kill(pid, 0) } == 0 {
+            // The primary's focus monitor polls this file (see
+            // `spawn_focus_monitor`); the secondary never signals it.
+            if let Some(request) = focus_request_path() {
+                let _ = fs::write(&request, b"1");
+            }
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn focus_request_path() -> Option<PathBuf> {
+    instance_lock_path().map(|lock| match lock.parent() {
+        Some(parent) => parent.join(FOCUS_REQUEST_FILE),
+        None => lock,
+    })
+}
+
+/// Returns true when this process should become the primary instance. When
+/// another live instance already owns the lock, this asks it to show its
+/// window and returns false so the caller can exit.
+#[cfg(target_os = "linux")]
+fn ensure_single_instance() -> bool {
+    let Some(path) = instance_lock_path() else {
+        return true;
+    };
+
+    // An existing live instance owns the lock: focus it and stay secondary.
+    if focus_existing_instance(&path) {
+        return false;
+    }
+
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    // The lock file can outlive its owner: a crashed, killed, or panicked
+    // instance never removes it, and a launch interrupted between open() and
+    // write() leaves an empty file. Reclaim it only when the recorded PID is
+    // no longer a live copy of this app, so a genuinely running instance is
+    // never displaced by a mistaken cleanup.
+    if path.exists() {
+        let owner_live = read_lock_pid(&path)
+            .map(|pid| process_is_our_app(pid) && unsafe { libc::kill(pid, 0) } == 0)
+            .unwrap_or(false);
+        if !owner_live {
+            let _ = fs::remove_file(&path);
+        }
+    }
+
+    // Claim the lock atomically so two near-simultaneous launches cannot both
+    // become primary. `create_new` (O_CREAT | O_EXCL) fails if the file exists.
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => {
+            let _ = file.write_all(std::process::id().to_string().as_bytes());
+            let _ = file.sync_all();
+            // Clear a focus request left behind by a crashed previous primary.
+            if let Some(request) = focus_request_path() {
+                let _ = fs::remove_file(request);
+            }
+            true
+        }
+        Err(_) => {
+            // Lost the race: defer to the instance that won the lock.
+            focus_existing_instance(&path);
+            false
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn remove_instance_lock() {
+    if let Some(path) = instance_lock_path() {
+        // Only remove a lock this process owns; never delete a lock that a
+        // racing launch reclaimed after our shutdown began.
+        if read_lock_pid(&path) == Some(std::process::id() as i32) {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_focus_monitor(app: AppHandle) {
+    thread::spawn(move || loop {
+        if let Some(request) = focus_request_path() {
+            if request.exists() {
+                // Consume the request before dispatching so a repeat request
+                // while the window cannot be raised still triggers a retry.
+                let _ = fs::remove_file(&request);
+                let value = app.clone();
+                let _ = app.run_on_main_thread(move || show_main_window(&value));
+            }
+        }
+        thread::sleep(Duration::from_millis(120));
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Become the single instance (Linux). If another live instance owns the
+    // lock, focus it and exit without starting a second server/window.
+    #[cfg(target_os = "linux")]
+    {
+        if !ensure_single_instance() {
+            std::process::exit(0);
+        }
+    }
+
     let desktop_api_token = load_or_generate_desktop_api_token()
         .expect("failed to create desktop API authorization token");
     let desktop_instance_id =
@@ -1008,6 +1208,9 @@ pub fn run() {
             #[cfg(not(target_os = "linux"))]
             build_platform_tray(app)?;
 
+            #[cfg(target_os = "linux")]
+            spawn_focus_monitor(app.handle().clone());
+
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -1032,6 +1235,8 @@ pub fn run() {
 
     app.run(|app_handle, event| match event {
         RunEvent::Exit => {
+            #[cfg(target_os = "linux")]
+            remove_instance_lock();
             if let Some(server) = app_handle.try_state::<DesktopServer>() {
                 server.stop();
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -698,12 +698,19 @@ fn bundled_node_path(resource_dir: &Path) -> PathBuf {
 
 #[cfg(all(feature = "custom-protocol", target_os = "linux"))]
 fn bundled_node_path(resource_dir: &Path) -> PathBuf {
+    // Resolution order: explicit override (distro packs point this at their
+    // own node, e.g. Nix store or /opt prefixes) > bundled runtime > the FHS
+    // default. Next.js requires Node >= 20.9.
+    if let Ok(p) = env::var("PI_DESKTOP_NODE") {
+        let path = PathBuf::from(&p);
+        if !p.is_empty() && path.is_file() {
+            return path;
+        }
+    }
     let bundled = resource_dir.join("resources/node/node");
     if bundled.is_file() {
         bundled
     } else {
-        // Linux packages may unbundle the runtime (e.g. the AUR package depends
-        // on system nodejs); fall back to it. Next.js requires Node >= 20.9.
         PathBuf::from("/usr/bin/node")
     }
 }
@@ -864,7 +871,7 @@ fn start_packaged_server(
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!(
-                "Node.js runtime is missing: {} (Linux falls back to system 'nodejs')",
+                "Node.js runtime is missing: {} (Linux: set PI_DESKTOP_NODE or install 'nodejs')",
                 node_path.display()
             ),
         )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -698,7 +698,14 @@ fn bundled_node_path(resource_dir: &Path) -> PathBuf {
 
 #[cfg(all(feature = "custom-protocol", target_os = "linux"))]
 fn bundled_node_path(resource_dir: &Path) -> PathBuf {
-    resource_dir.join("resources/node/node")
+    let bundled = resource_dir.join("resources/node/node");
+    if bundled.is_file() {
+        bundled
+    } else {
+        // Linux packages may unbundle the runtime (e.g. the AUR package depends
+        // on system nodejs); fall back to it. Next.js requires Node >= 20.9.
+        PathBuf::from("/usr/bin/node")
+    }
 }
 
 #[cfg(feature = "custom-protocol")]
@@ -856,7 +863,10 @@ fn start_packaged_server(
     if !node_path.is_file() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
-            format!("Bundled Node runtime is missing: {}", node_path.display()),
+            format!(
+                "Node.js runtime is missing: {} (Linux falls back to system 'nodejs')",
+                node_path.display()
+            ),
         )
         .into());
     }


### PR DESCRIPTION
Linux desktop stability fixes (single squash commit):

- **Single-instance focus**: the secondary launch now asks the running
  instance to raise its window via a polled request file instead of
  raising SIGUSR1 — JavaScriptCore owns SIGUSR1 on Linux and a stray
  signal corrupts the process (SEGV inside WebKit).
- **Quitting**: the packaged Node server is reaped on a detached thread,
  so closing the window no longer blocks until the server exits.
- **Theme switching**: `document.startViewTransition` crashes WebKitGTK's
  UI process, so the desktop shell uses the existing instant-switch
  fallback; the shell also stops registering the PWA service worker and
  unregisters leftovers, since a stale worker keeps serving old bundles
  across reinstalls (which resurrected the crash).
- **Build**: `prepare-desktop.mjs` strips `__NEXT_PRIVATE_STANDALONE_CONFIG`
  from the `next build` child env — the packaged server leaks it into
  spawned process trees and its JSON-dehydrated config drops function
  values (`generateBuildId`), breaking the build.
- .gitignore: `/.pi/` and the staged Node runtime dir.