### PR TITLE
fix: stop GFM autolinks from swallowing trailing CJK text

### DIFF
--- a/components/MarkdownBody.test.mjs
+++ b/components/MarkdownBody.test.mjs
@@ -30,6 +30,17 @@ test("opens non-file markdown links in a safe new tab", () => {
   assert.doesNotMatch(html, /\snode=/);
 });
 
+test("does not swallow trailing CJK text into a GFM autolink", () => {
+  const html = renderMarkdown(
+    "看 https://github.com/abcwyc/pi-agent-desktop/issues/48，然后来解决一下",
+  );
+
+  assert.match(
+    html,
+    /<a [^>]*href="https:\/\/github\.com\/abcwyc\/pi-agent-desktop\/issues\/48"[^>]*>https:\/\/github\.com\/abcwyc\/pi-agent-desktop\/issues\/48<\/a>，然后来解决一下/,
+  );
+});
+
 test("keeps local file markdown links in the app", () => {
   const html = renderMarkdown("[file](components/MarkdownBody.tsx)");
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -314,8 +314,42 @@ function normalizeInlineLatexMath(line: string): string {
   );
 }
 
-export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
-export const markdownPreviewRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
+/**
+ * GFM autolink literals greedily include non-ASCII characters (e.g. CJK) as part of a URL,
+ * so `https://foo.com/x中文` becomes one giant link. Split trailing non-ASCII runs back out
+ * into text after the link node.
+ */
+function remarkTrimAutolinkTrailingUnicode() {
+  return (tree: unknown) => {
+    const walk = (node: any) => {
+      if (!node || typeof node !== "object" || !Array.isArray(node.children)) return;
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        if (
+          child?.type === "link" &&
+          Array.isArray(child.children) &&
+          child.children.length === 1 &&
+          child.children[0].type === "text" &&
+          child.children[0].value === child.url
+        ) {
+          const match = /[^\x00-\x7F]/u.exec(child.url);
+          if (match && match.index > 0) {
+            const kept = child.url.slice(0, match.index);
+            const tail = child.url.slice(match.index);
+            child.url = kept;
+            child.children[0].value = kept;
+            node.children.splice(i + 1, 0, { type: "text", value: tail });
+          }
+        }
+        walk(child);
+      }
+    };
+    walk(tree);
+  };
+}
+
+export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath, remarkTrimAutolinkTrailingUnicode];
+export const markdownPreviewRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath, remarkTrimAutolinkTrailingUnicode];
 
 export const markdownRehypePlugins: ReactMarkdownOptions["rehypePlugins"] = [
   rehypeRaw,


### PR DESCRIPTION
Fixes #50.

## Summary

- `remark-gfm` autolink literals treat any non-ASCII character as a valid URL character, so `https://foo.com/x中文` renders as one big link that points to a percent-encoded nonsense URL.
- Add a tiny remark post-pass (`remarkTrimAutolinkTrailingUnicode`) that visits link nodes produced by GFM autolink literal, cuts the URL at the first non-ASCII code point, and re-emits the trailing run as a plain text sibling.
- Only touches nodes where `link.url === text.value` (the shape GFM autolink literal produces), so explicit `[label](url)` and `<url>` autolinks are untouched.

## Before / after

Input: `看 https://github.com/abcwyc/pi-agent-desktop/issues/48，然后来解决一下`

- Before: `<a href="https://github.com/abcwyc/pi-agent-desktop/issues/48%EF%BC%8C…">https://github.com/…/48，然后来解决一下</a>`
- After : `<a href="https://github.com/abcwyc/pi-agent-desktop/issues/48">https://github.com/…/48</a>，然后来解决一下`

## Test plan

- [x] `node --test components/MarkdownBody.test.mjs` — 9/9 pass, new test covers the CJK case.
- [x] Manually verified other autolink shapes are unchanged: URL followed by ASCII space, URL followed by ASCII punctuation, URL inside `<...>` angle-bracket autolink, explicit `[label](url)` link.