### PR TITLE
fix: type remark autolink-trim plugin without `any` (unbreak lint)

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -319,32 +319,40 @@ function normalizeInlineLatexMath(line: string): string {
  * so `https://foo.com/x中文` becomes one giant link. Split trailing non-ASCII runs back out
  * into text after the link node.
  */
+interface MdastNodeLike {
+  type?: string;
+  url?: string;
+  value?: string;
+  children?: MdastNodeLike[];
+}
+
 function remarkTrimAutolinkTrailingUnicode() {
   return (tree: unknown) => {
-    const walk = (node: any) => {
+    const walk = (node: MdastNodeLike | undefined) => {
       if (!node || typeof node !== "object" || !Array.isArray(node.children)) return;
       for (let i = 0; i < node.children.length; i++) {
         const child = node.children[i];
+        const textChild = child.children?.[0];
         if (
-          child?.type === "link" &&
-          Array.isArray(child.children) &&
-          child.children.length === 1 &&
-          child.children[0].type === "text" &&
-          child.children[0].value === child.url
+          child.type === "link" &&
+          typeof child.url === "string" &&
+          child.children?.length === 1 &&
+          textChild?.type === "text" &&
+          textChild.value === child.url
         ) {
           const match = /[^\x00-\x7F]/u.exec(child.url);
           if (match && match.index > 0) {
             const kept = child.url.slice(0, match.index);
             const tail = child.url.slice(match.index);
             child.url = kept;
-            child.children[0].value = kept;
+            textChild.value = kept;
             node.children.splice(i + 1, 0, { type: "text", value: tail });
           }
         }
         walk(child);
       }
     };
-    walk(tree);
+    walk(tree as MdastNodeLike);
   };
 }
 


### PR DESCRIPTION
## Context

PR #51 (merged) added `remarkTrimAutolinkTrailingUnicode` to `lib/markdown.ts` with an `any`-typed walker. `eslint` has `@typescript-eslint/no-explicit-any` as an error, so `npm run lint` now fails on `main` (the repo has no CI to have caught this pre-merge).

## Change

- Replace the `any` parameter with a minimal local `MdastNodeLike` interface.
- Behavior is unchanged; added `typeof child.url === "string"` narrowing as a side benefit.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean (was failing on `main`)
- `node --test components/MarkdownBody.test.mjs` — 9/9 pass (incl. the CJK autolink case from #51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)