### PR TITLE
支持 RPC 模式下的工厂型扩展小组件

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -994,8 +994,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 </div>
               ) : (
                 <>
-              <ExtensionWidgets widgets={aboveEditorWidgets} />
-
             {renderedMessages}
             {streamState.isStreaming && streamState.streamingMessage && (
               <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} cwd={messageCwd} onOpenFile={onOpenFile} />
@@ -1052,10 +1050,15 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
           }}
         >
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
-            <ExtensionWidgets widgets={belowEditorWidgets} />
+            <ExtensionWidgets widgets={aboveEditorWidgets} />
           </div>
         </div>
         {chatInputElement}
+        <div style={{ padding: `0 ${CHAT_COLUMN_PADDING}px` }}>
+          <div style={{ maxWidth: 820, margin: "0 auto" }}>
+            <ExtensionWidgets widgets={belowEditorWidgets} />
+          </div>
+        </div>
       </div>
       </div>
       </>

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -138,6 +138,19 @@ test("headless theme supplies Pi 0.84's required background fallback", async () 
   assert.match(source, /\{ selectedBg: "" \} as ConstructorParameters<typeof Theme>\[1\]/);
 });
 
+test("RPC extension UI renders factory-form widgets and releases them on reload", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const setWidgetSource = source.slice(
+    source.indexOf("private setExtensionWidget"),
+    source.indexOf("private getCustomUiWidth"),
+  );
+
+  assert.match(setWidgetSource, /typeof content !== "function"/);
+  assert.match(setWidgetSource, /createHeadlessCustomUiTui\(\(\) => this\.renderExtensionWidget\(key\)\)/);
+  assert.match(setWidgetSource, /this\.renderExtensionWidget\(key\)/);
+  assert.match(source, /this\.clearExtensionWidgets\(\);\s*this\.syncProjectTrust\(\);/);
+});
+
 test("reloading a session invalidates the models cache", async () => {
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const reloadSource = source.slice(

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -47,6 +47,16 @@ type ActiveCustomUi = {
   settled: boolean;
 };
 
+type ExtensionWidgetComponent = {
+  render: (width: number) => string[];
+  dispose?: () => void;
+};
+
+type ActiveExtensionWidget = {
+  component: ExtensionWidgetComponent;
+  placement: "aboveEditor" | "belowEditor";
+};
+
 type ExtensionUiRequestBody = Record<string, unknown> & {
   method: ExtensionUiRequest["method"];
   timeout?: number;
@@ -162,6 +172,7 @@ export class AgentSessionWrapper {
   private pendingUiResponses = new Map<string, PendingUiResponse>();
   private pendingUiRequests = new Map<string, AgentEvent>();
   private activeCustomUis = new Map<string, ActiveCustomUi>();
+  private activeExtensionWidgets = new Map<string, ActiveExtensionWidget>();
   private extensionStatuses = new Map<string, string>();
   private extensionWidgets = new Map<string, ExtensionWidgetItem>();
   private promptRunning = false;
@@ -666,7 +677,7 @@ export class AgentSessionWrapper {
       case "reload": {
         await this.waitForExtensionsBound();
         this.extensionStatuses.clear();
-        this.extensionWidgets.clear();
+        this.clearExtensionWidgets();
         this.syncProjectTrust();
         await this.inner.reload();
         if (typeof this.inner.bindExtensions !== "function") {
@@ -736,6 +747,7 @@ export class AgentSessionWrapper {
     this.unsubscribe?.();
     for (const pending of this.pendingUiResponses.values()) pending.cancel();
     for (const id of Array.from(this.activeCustomUis.keys())) this.closeCustomUi(id, undefined);
+    this.clearExtensionWidgets();
     this.pendingUiResponses.clear();
     this.pendingUiRequests.clear();
     // Release SSE event listeners so destroyed wrappers don't keep response
@@ -786,6 +798,99 @@ export class AgentSessionWrapper {
 
   private getExtensionWidgets(): ExtensionWidgetItem[] {
     return Array.from(this.extensionWidgets.values());
+  }
+
+  private clearExtensionWidget(key: string): void {
+    const active = this.activeExtensionWidgets.get(key);
+    this.activeExtensionWidgets.delete(key);
+    this.extensionWidgets.delete(key);
+    try {
+      active?.component.dispose?.();
+    } catch {
+      // Ignore dispose errors from extension UI components.
+    }
+  }
+
+  private clearExtensionWidgets(): void {
+    for (const key of Array.from(this.activeExtensionWidgets.keys())) {
+      this.clearExtensionWidget(key);
+    }
+    this.extensionWidgets.clear();
+  }
+
+  private renderExtensionWidget(key: string): void {
+    const active = this.activeExtensionWidgets.get(key);
+    if (!active) return;
+
+    let lines: string[];
+    try {
+      lines = active.component.render(DEFAULT_CUSTOM_UI_COLUMNS);
+    } catch (error) {
+      lines = [`Extension widget render failed: ${error instanceof Error ? error.message : String(error)}`];
+    }
+    this.extensionWidgets.set(key, { key, lines, placement: active.placement });
+    this.emit({
+      type: "extension_ui_request",
+      id: randomUUID(),
+      method: "setWidget",
+      widgetKey: key,
+      widgetLines: lines,
+      widgetPlacement: active.placement,
+    } as ExtensionUiRequest as AgentEvent);
+  }
+
+  private setExtensionWidget(
+    key: string,
+    content: unknown,
+    options?: { placement?: "aboveEditor" | "belowEditor" },
+  ): void {
+    this.clearExtensionWidget(key);
+    if (content === undefined) {
+      this.emit({
+        type: "extension_ui_request",
+        id: randomUUID(),
+        method: "setWidget",
+        widgetKey: key,
+        widgetLines: undefined,
+        widgetPlacement: options?.placement,
+      } as ExtensionUiRequest as AgentEvent);
+      return;
+    }
+
+    if (Array.isArray(content)) {
+      const placement = options?.placement ?? "aboveEditor";
+      this.extensionWidgets.set(key, { key, lines: content, placement });
+      this.emit({
+        type: "extension_ui_request",
+        id: randomUUID(),
+        method: "setWidget",
+        widgetKey: key,
+        widgetLines: content,
+        widgetPlacement: placement,
+      } as ExtensionUiRequest as AgentEvent);
+      return;
+    }
+
+    if (typeof content !== "function") return;
+
+    const tui = createHeadlessCustomUiTui(() => this.renderExtensionWidget(key));
+    try {
+      const component = content(tui, PLAIN_TEXT_THEME);
+      if (!component || typeof component !== "object" || typeof component.render !== "function") return;
+      const placement = options?.placement ?? "aboveEditor";
+      this.activeExtensionWidgets.set(key, {
+        component: component as ExtensionWidgetComponent,
+        placement,
+      });
+      this.renderExtensionWidget(key);
+    } catch (error) {
+      this.emit({
+        type: "extension_error",
+        extensionPath: `widget:${key}`,
+        event: "setWidget",
+        error: error instanceof Error ? error.message : String(error),
+      } as AgentEvent);
+    }
   }
 
   private getCustomUiWidth(options: unknown): number {
@@ -1021,24 +1126,7 @@ export class AgentSessionWrapper {
       setWorkingIndicator: () => {},
       setHiddenThinkingLabel: () => {},
       setWidget: (key, content, options) => {
-        if (content !== undefined && !Array.isArray(content)) return;
-        if (content === undefined) {
-          this.extensionWidgets.delete(key);
-        } else {
-          this.extensionWidgets.set(key, {
-            key,
-            lines: content,
-            placement: options?.placement ?? "aboveEditor",
-          });
-        }
-        this.emit({
-          type: "extension_ui_request",
-          id: randomUUID(),
-          method: "setWidget",
-          widgetKey: key,
-          widgetLines: content,
-          widgetPlacement: options?.placement,
-        } as ExtensionUiRequest as AgentEvent);
+        this.setExtensionWidget(key, content, options);
       },
       setFooter: () => {},
       setHeader: () => {},
@@ -1095,7 +1183,7 @@ export class AgentSessionWrapper {
       switchSession: async () => ({ cancelled: true }),
       reload: async () => {
         this.extensionStatuses.clear();
-        this.extensionWidgets.clear();
+        this.clearExtensionWidgets();
         this.syncProjectTrust();
         await this.inner.reload({
           beforeSessionStart: () => {


### PR DESCRIPTION
支持 RPC 模式下的工厂型扩展小组件

## 问题

Pi 的 `ExtensionUIContext.setWidget()` 支持传入字符串数组或组件工厂。桌面端的 RPC 桥接目前只处理字符串数组，并会直接忽略组件工厂。

因此，使用工厂型小组件的扩展（例如 `@juicesharp/rpiv-todo`）虽然可以注册 `todo` 工具和 `/todos` 命令，但实时待办面板不会显示。

## 修改内容

- 为 RPC 会话保存工厂创建的小组件及其显示位置。
- 使用现有的无头 TUI 和纯文本主题渲染工厂小组件，并将结果通过现有 `setWidget` 事件发送给 Web UI。
- 处理小组件主动调用 `tui.requestRender()` 的刷新请求。
- 在替换、重载和销毁会话时释放小组件，避免遗留状态和资源。
- 新增回归测试，覆盖工厂型小组件的渲染和重载清理路径。

## 验证

- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `npm test`

以上检查均通过。

## 验证步骤

1. 安装 `npm:@juicesharp/rpiv-todo`。
2. 新建或重启 Pi Agent Desktop 会话。
3. 让代理调用 `todo` 工具创建任务。
4. 确认输入框上方出现并会更新待办面板。
