### PR TITLE
fix: restore jiti entry files dropped by Next file tracer

### DIFF
--- a/scripts/prepare-desktop.mjs
+++ b/scripts/prepare-desktop.mjs
@@ -67,6 +67,24 @@ async function assembleServer() {
     await cp(source, destination, { recursive: true, force: true });
   }
 
+  // Next's file tracer drops jiti's top-level entries (lib/jiti.cjs / lib/
+  // jiti.mjs): the pi-coding-agent bundle reaches jiti only through a lazy
+  // require("jiti") that tracing cannot follow, so only lib/jiti-static.mjs
+  // survives and extension loading fails with "Cannot find module
+  // .../jiti/lib/jiti.cjs". Ship the complete source package over it.
+  await cp(
+    join(rootDir, "node_modules", "jiti"),
+    join(
+      serverResourcesDir,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "node_modules",
+      "jiti",
+    ),
+    { recursive: true, force: true },
+  );
+
   await copyFile(
     join(rootDir, "desktop", "server-launcher.cjs"),
     join(serverResourcesDir, "desktop-server.cjs"),


### PR DESCRIPTION
The pi-coding-agent bundle reaches jiti only through a lazy require("jiti") at runtime, which Next's standalone file tracer cannot follow statically. As a result the packaged server keeps only lib/jiti-static.mjs and drops the top-level entries (lib/jiti.cjs / lib/jiti.mjs) that the package exports map points require() at. Loading any TypeScript extension then fails with:

```
  Cannot find module
  .../pi-coding-agent/node_modules/jiti/lib/jiti.cjs
```

Ship the complete source jiti package over the traced copy during assembleServer so the packaged tree matches a real npm install.